### PR TITLE
Security Credential Upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,93 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - dev
+      - release
+      - feature/security-credential-upgrade
+  pull_request:
+    branches:
+      - dev
+      - release
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  test:
+    name: Swift 6 Tests and Coverage
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Toolchain
+        run: |
+          swift --version
+          xcodebuild -version
+
+      - name: Resolve package
+        run: swift package resolve
+
+      - name: Select iPhone simulator
+        id: simulator
+        run: |
+          set -euo pipefail
+          SIMULATOR_ID="$(xcrun simctl list devices available | awk -F '[()]' '/iPhone/ { print $2; exit }')"
+          if [ -z "$SIMULATOR_ID" ]; then
+            echo "No available iPhone simulator found." >&2
+            exit 1
+          fi
+          echo "id=$SIMULATOR_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Test with coverage
+        run: |
+          set -euo pipefail
+          rm -rf TestResults.xcresult coverage.json
+          xcodebuild test \
+            -scheme PatternAuthentication \
+            -destination "id=${{ steps.simulator.outputs.id }}" \
+            -enableCodeCoverage YES \
+            -resultBundlePath TestResults.xcresult \
+            SWIFT_VERSION=6 \
+            SWIFT_STRICT_CONCURRENCY=complete
+
+      - name: Generate coverage report
+        run: xcrun xccov view --report --json TestResults.xcresult > coverage.json
+
+      - name: Enforce 90 percent coverage
+        run: |
+          python3 Scripts/check_coverage.py coverage.json \
+            --threshold 90 \
+            --ignore Sources/PatternAuthentication/PatternAuthentication.swift
+
+      - name: Convert coverage for Codecov
+        id: coverage-files
+        uses: sersoft-gmbh/swift-coverage-action@v5
+        with:
+          search-paths: TestResults.xcresult
+          output: .swiftcov
+          format: lcov
+          target-name-filter: PatternAuthentication
+          ignore-filename-regex: "(.*/Tests/.*|.*/Sources/PatternAuthentication/PatternAuthentication.swift)"
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: |
+            coverage.json
+            .swiftcov
+            TestResults.xcresult
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          files: ${{ join(fromJSON(steps.coverage-files.outputs.files), ',') }}
+          fail_ci_if_error: false
+          name: PatternAuthentication
+          swift_project: PatternAuthentication
+          use_oidc: true

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 /Packages
 xcuserdata/
 DerivedData/
+.swiftcov/
+/coverage.json
+/TestResults.xcresult
 .swiftpm/configuration/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ The security credential upgrade release keeps the original 1.x gesture UI APIs a
 
 ### Deprecated
 
-- Deprecated `hashArray(_:)`. Use `GestureCredentialEnvelope.create(from:configuration:)` or the new `GridAuthenticator(.setCredential(...))` flow instead.
+- Deprecated `hashArray(_:)`. Use `GestureCredentialHasher.createCredential(for:configuration:)` or the new `GridAuthenticator(.setCredential(...))` flow instead.
 - Deprecated `GridAuthenticator(.set(... completion: (String) -> Void))`. Use `GridAuthenticator(.setCredential(...))` for new setup flows.
 - Deprecated `GridAuthenticator(.authenticate(expectedHash: ...))`. Use `GridAuthenticator(.authenticateCredential(...))` once a v1 envelope is stored.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,100 @@
+# Changelog
+
+This project follows semantic versioning. Major releases handle public API removals when possible.
+
+## Unreleased
+
+- No unreleased changes yet.
+
+## 1.1.0 - 2026-06-12
+
+The security credential upgrade release keeps the original 1.x gesture UI APIs available for existing apps and adds the v1 credential-envelope flow for production use.
+
+### Added
+
+- Added the v1 `GestureCredentialEnvelope` API for storing gesture credentials as a structured envelope rather than a single legacy hash string.
+- Added `GesturePattern` to canonicalize selected grid indices before hashing, including a package-specific domain separator so the encoded gesture carries package and version context.
+- Added `GestureHashConfiguration` for KDF parameters, with `.recommended` using PBKDF2-HMAC-SHA256, 600,000 iterations, a 32-byte salt, and a 32-byte derived key.
+- Added `GestureKDF` so stored credentials can record the derivation algorithm used to create them.
+- Added `GestureCredentialError` for typed failures around salt generation, hashing, unsupported credential versions, malformed base64, malformed JSON, and invalid KDF metadata.
+- Added cryptographically secure random salt generation through Security framework APIs.
+- Added constant-time comparison for derived hash verification.
+- Added `Codable`, JSON, and base64 helpers for backend-friendly storage in document databases and APIs.
+- Added `GridAuthenticator(.setCredential(...))` for new credential setup.
+- Added `GridAuthenticator(.authenticateCredential(...))` for authenticating against a fetched v1 credential.
+- Added `GridAuthenticator(.authenticateAndUpgrade(...))` for verifying a legacy v0 hash and returning a v1 credential envelope after a successful match.
+- Added Swift 6 language mode in `Package.swift`.
+- Added `Sendable` conformance for credential model types that can safely cross concurrency boundaries.
+- Added main-actor isolation for UI-owned state.
+- Added package tests for canonical gesture encoding, PBKDF2-HMAC-SHA256 known vectors, salt uniqueness, v1 credential verification, Codable round trips, base64 round trips, legacy verification, legacy-to-v1 migration, particle resource loading, and replay path behavior.
+- Added GitHub Actions CI for Swift 6 builds, tests, coverage extraction, and a 90% package-logic coverage gate.
+- Added Codecov configuration, LCOV conversion for Swift/Xcode coverage upload, and README badges for CI and coverage.
+- Added a DocC catalog for package documentation.
+- Added public API DocC comments for the non-view public types and methods.
+- Added `Docs/MigrationGuide.md` for legacy SHA-256 migration.
+- Added `SECURITY.md` with storage, lockout, session, and vulnerability-reporting guidance.
+
+### Changed
+
+- Reworked the README into a production integration guide with quickstart setup/authentication examples, backend responsibilities, Firestore-style storage guidance, security model notes, configuration defaults, troubleshooting, and versioning.
+- Updated the package security model from unsalted SHA-256-only storage to a salted credential envelope while preserving source compatibility for existing 1.x clients.
+- Updated setup and authentication examples to show app-owned backend fetch/save behavior.
+- Updated particle rendering so the particle canvas, drag hit testing, and circle geometry all use the same grid-local coordinate space.
+- Updated particle trails to interpolate fast drag movement and render at a fingertip-like thickness, reducing dotted gaps during quick swipes.
+- Preserved the original particle-only visual style rather than switching to a deterministic path overlay.
+- Updated SwiftUI layout so the grid itself defines the interactive drawing surface, avoiding full-screen coordinate drift in package consumers.
+- Updated debug behavior so raw gesture hashes are no longer printed.
+- Updated setup without confirmation so it completes after the first valid gesture while still honoring the default `repeatInput: true` replay.
+- Updated failed authentication behavior so the completion handler is called with `false`.
+- Updated the mutable static preference default to be Swift 6 concurrency friendly.
+
+### Deprecated
+
+- Deprecated `hashArray(_:)`. Use `GestureCredentialEnvelope.create(from:configuration:)` or the new `GridAuthenticator(.setCredential(...))` flow instead.
+- Deprecated `GridAuthenticator(.set(... completion: (String) -> Void))`. Use `GridAuthenticator(.setCredential(...))` for new setup flows.
+- Deprecated `GridAuthenticator(.authenticate(expectedHash: ...))`. Use `GridAuthenticator(.authenticateCredential(...))` once a v1 envelope is stored.
+
+### Fixed
+
+- Fixed particle trails that could appear vertically offset from the selected circles in SwiftPM consumers.
+- Fixed particle trails that could look like a dotted line during fast finger movement.
+- Fixed replay cleanup so a previous path does not bleed into the next setup or authentication attempt.
+- Fixed SwiftPM resource loading coverage for the `spark` asset bundle.
+- Fixed failed authentication callbacks so integrators can reliably update UI after an incorrect pattern.
+
+### Security
+
+- New v1 credentials use a fresh per-credential salt and PBKDF2-HMAC-SHA256 rather than a raw unsalted gesture hash.
+- Verification derives a candidate hash with the stored credential parameters and compares it in constant time.
+- Credential metadata records KDF, iteration count, hash version, and derived key length so future migrations have enough context.
+- Legacy SHA-256 APIs remain only for compatibility and migration. New production integrations should use v1 credentials.
+- Apps remain responsible for backend storage, authorization, sessions, lockouts, attempt limits, audit logging, recovery, and deciding what a successful gesture unlocks.
+
+### Backwards Compatibility
+
+- This release adds APIs in 1.x.
+- Existing calls to `GridAuthenticator(.set(... completion: (String) -> Void))`, `GridAuthenticator(.authenticate(expectedHash: ...))`, and `hashArray(_:)` should continue to compile with deprecation warnings.
+- Existing stored legacy hashes can still be verified.
+- Existing production apps can migrate one user at a time with `authenticateAndUpgrade` after a successful legacy match.
+- `repeatInput` remains `true` by default.
+- Apps that exhaustively switch over package enums may need to recompile and handle newer cases.
+- Apps that depended on raw debug hash output should remove that dependency.
+
+### Migration Notes
+
+- For new users, store `GestureCredentialEnvelope.Base64Representation` fields in your app-owned backend or local secure storage.
+- For existing users, keep the legacy hash until `authenticateAndUpgrade` succeeds and your app has saved the returned v1 credential.
+- Do not delete a legacy hash if saving the new envelope fails.
+- Store all v1 fields together: `salt`, `hash`, `kdf`, `iterations`, `hashVersion`, and `derivedKeyLength`.
+- Treat the credential record as sensitive authenticator material.
+
+### Testing
+
+- Verified Swift 6 package builds for iOS.
+- Added a focused package test suite covering credential creation, verification, migration, encoding, resources, and particle behavior.
+- Added CI coverage enforcement at 90% or higher for package logic.
+- Verified the updated package through the sibling `PatternAuthTest` app on a physical iPhone.
+
+### Known Non-Goals
+
+- Argon2id remains a candidate for memory-hard offline attack resistance. v1 uses PBKDF2-HMAC-SHA256 to keep the package dependency-free and SwiftPM-friendly.

--- a/Docs/MigrationGuide.md
+++ b/Docs/MigrationGuide.md
@@ -1,0 +1,83 @@
+# Migration Guide
+
+This guide covers migration from the original unsalted SHA-256 API to the v1 credential envelope API.
+
+## What changed
+
+The original API returned a single string from setup and accepted that string during authentication:
+
+```swift
+GridAuthenticator(.set { hash in
+    saveLegacyHash(hash)
+})
+
+GridAuthenticator(.authenticate(expectedHash: legacyHash) { success in
+    handleResult(success)
+})
+```
+
+The v1 API returns a `GestureCredentialEnvelope` containing the salt, derived hash, KDF, iteration count, hash version, and derived key length:
+
+```swift
+GridAuthenticator(.setCredential { credential in
+    saveCredential(credential)
+})
+
+GridAuthenticator(.authenticateCredential(credential: credential) { success in
+    handleResult(success)
+})
+```
+
+## New installs
+
+Use `setCredential` for setup and store the envelope's base64 representation in your backend or local secure storage.
+
+```swift
+GridAuthenticator(.setCredential(
+    minimumVertices: 6,
+    requireConfirmation: true,
+    repeatInput: true
+) { credential in
+    Task {
+        try await saveCredential(credential.base64Representation)
+    }
+})
+```
+
+## Existing installs
+
+For users who already have a legacy hash, authenticate once with `authenticateAndUpgrade`.
+
+```swift
+GridAuthenticator(.authenticateAndUpgrade(
+    expectedHash: legacyHash,
+    onCredentialUpgrade: { credential in
+        Task {
+            try await saveCredential(credential.base64Representation)
+            try await removeLegacyHash()
+        }
+    },
+    completion: { success in
+        handleResult(success)
+    }
+))
+```
+
+Only remove the legacy hash after the v1 credential write succeeds. If the write fails, keep the legacy hash and retry on a later successful login.
+
+## Backwards compatibility
+
+The legacy APIs remain available for 1.x and are marked deprecated. This lets production apps migrate users gradually without a forced data conversion.
+
+Two behavior fixes are worth testing in your app:
+
+- Failed authentication calls the completion with `false`.
+- Setup without confirmation now completes immediately after a valid gesture.
+
+## Backend checklist
+
+- Store all envelope fields: `salt`, `hash`, `kdf`, `iterations`, `hashVersion`, and `derivedKeyLength`.
+- Store `salt` and `hash` as base64 strings if your database cannot store binary data cleanly.
+- Protect credential reads and writes with your normal account authorization rules.
+- Do not log raw credentials or legacy hashes.
+- Keep lockout, rate limiting, session creation, and authorization checks outside the package.

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -17,9 +17,14 @@ let package = Package(
         .target(
             name: "PatternAuthentication",
             dependencies: [],
-            path: "Sources",
-            exclude: ["Images"],
+            path: "Sources/PatternAuthentication",
             resources: [.process("Media.xcassets")]
         ),
-    ]
+        .testTarget(
+            name: "PatternAuthenticationTests",
+            dependencies: ["PatternAuthentication"],
+            path: "Tests/PatternAuthenticationTests"
+        ),
+    ],
+    swiftLanguageModes: [.v6]
 )

--- a/README.md
+++ b/README.md
@@ -1,125 +1,299 @@
-[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FApex-Studios-LLC%2FPatternAuthentication%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/Apex-Studios-LLC/PatternAuthentication) [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FApex-Studios-LLC%2FPatternAuthentication%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/Apex-Studios-LLC/PatternAuthentication)
+[![Swift versions](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FApex-Studios-LLC%2FPatternAuthentication%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/Apex-Studios-LLC/PatternAuthentication)
+[![Platforms](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FApex-Studios-LLC%2FPatternAuthentication%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/Apex-Studios-LLC/PatternAuthentication)
+[![CI](https://github.com/Apex-Studios-LLC/PatternAuthentication/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/Apex-Studios-LLC/PatternAuthentication/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/Apex-Studios-LLC/PatternAuthentication/branch/dev/graph/badge.svg)](https://codecov.io/gh/Apex-Studios-LLC/PatternAuthentication)
+
 # Pattern Authentication
 
-Pattern Authentication is a Swift package that provides a customizable 3x3 grid-based pattern authentication system for iOS applications. It offers a secure and visually appealing way to implement user authentication or pattern creation. This is useful in applications that may be on multi-user devices to eliminate needing to have every user login via email/password auth.
+Pattern Authentication gives iOS apps a polished 3x3 gesture-pattern setup and authentication flow. Multi-user apps can use it for profile switching, household access, or secondary checks without asking each user for a password on each handoff.
 
-[](https://github.com/user-attachments/assets/34d3c5b0-3a0f-4a1f-b5b0-207aae6a9ef5)
+The package owns the client-side gesture UI, canonical pattern encoding, salted credential creation, credential verification, legacy migration helpers, and particle-path feedback.
 
+Your app owns the backend, account model, lockout policy, session creation, and authorization checks. Fetch stored credentials, save new credentials, enforce attempt limits, and grant access after a successful gesture match in your app or service.
 
-## Features
-
-- Grid-based pattern authentication
-- Customizable appearance (colors, interaction modes)
-- Support for both authentication and pattern creation
-- Particle effects for enhanced visual feedback
-- Shake animation for incorrect attempts
-- Debug mode for development and testing
-- Minimum pattern length enforcement
-- Cryptographic hashing for secure pattern storage
+[Demo video](Images/PatternAuthenticationDemo.mp4)
 
 ## Requirements
 
 - iOS 15.0+
-- Swift 5.10+
+- Swift 6.0+
+- Xcode 16+ or a Swift 6-compatible toolchain
 
-## Installation
+## Install
 
-### Swift Package Manager
+Add the package in Xcode:
 
-Add the following line to your `Package.swift` file's dependencies:
-
-```swift
-.package(url: "https://github.com/yourusername/PatternAuthentication.git", from: "1.0.0")
+```text
+https://github.com/Apex-Studios-LLC/PatternAuthentication.git
 ```
 
-Then, include "PatternAuthentication" as a dependency for your target:
+Or add it to a `Package.swift` manifest:
 
 ```swift
-.target(name: "YourTarget", dependencies: ["PatternAuthentication"]),
+.package(
+    url: "https://github.com/Apex-Studios-LLC/PatternAuthentication.git",
+    from: "1.1.0"
+)
 ```
 
-## Usage
+Then add `PatternAuthentication` to your app target.
 
-### Importing the Package
+```swift
+.target(
+    name: "YourApp",
+    dependencies: ["PatternAuthentication"]
+)
+```
+
+## Quick Start
+
+Import the package anywhere you present the gesture UI.
 
 ```swift
 import PatternAuthentication
+import SwiftUI
 ```
 
-### Creating a Pattern Setup View
+Create a new v1 credential during setup:
 
 ```swift
-GridAuthenticator(.set(
-    minimumVertices: 6,
-    color: .green,
-    interactionMode: .drag,
-    requireConfirmation: true,
-    repeatInput: true,
-    debug: false
-) { hash in
-    print("New pattern hash: \(hash)")
-    // Store this hash securely for later authentication
-    // if `requireConfirmation` is set to true it will automatically have the user confirm the pattern prior to calling completion
-})
-```
+struct GestureSetupView: View {
+    let userID: String
+    let saveCredential: (String, GestureCredentialEnvelope) async throws -> Void
 
-### Creating an Authentication View
+    @State private var status = ""
 
-```swift
-let expectedHash = user.patternHash // retrieve expected hash from storage
-
-GridAuthenticator(.authenticate(
-    expectedHash: expectedHash,
-    color: .blue,
-    interactionMode: .drag,
-    debug: false
-) { success in
-    if success {
-        print("Authentication successful")
-         // here's where we would navigate to a new authenticated area, show a success animation, etc
-    } else {
-        print("Authentication failed")
-         // here's where we would show a failure message, increase attempt counts, etc
+    var body: some View {
+        GridAuthenticator(.setCredential(
+            minimumVertices: 6,
+            color: .green,
+            interactionMode: .drag,
+            requireConfirmation: true,
+            repeatInput: true,
+            debug: false
+        ) { credential in
+            Task {
+                do {
+                    try await saveCredential(userID, credential)
+                    status = "Pattern saved"
+                } catch {
+                    status = "Could not save pattern"
+                }
+            }
+        })
     }
+}
+```
+
+Authenticate against a credential your app fetched from storage:
+
+```swift
+struct GestureLoginView: View {
+    let credential: GestureCredentialEnvelope
+    let onAuthenticated: () -> Void
+
+    @State private var failed = false
+
+    var body: some View {
+        GridAuthenticator(.authenticateCredential(
+            credential: credential,
+            color: .blue,
+            interactionMode: .drag,
+            debug: false
+        ) { success in
+            if success {
+                onAuthenticated()
+            } else {
+                failed = true
+            }
+        })
+    }
+}
+```
+
+## Credential Flow
+
+The v1 API returns a `GestureCredentialEnvelope`:
+
+```swift
+public struct GestureCredentialEnvelope: Codable, Hashable, Sendable {
+    public let salt: Data
+    public let hash: Data
+    public let kdf: GestureKDF
+    public let iterations: Int
+    public let hashVersion: Int
+    public let derivedKeyLength: Int
+}
+```
+
+For JSON or document databases, use the base64 representation:
+
+```swift
+let representation = credential.base64Representation
+
+let payload: [String: Any] = [
+    "salt": representation.salt,
+    "hash": representation.hash,
+    "kdf": representation.kdf.rawValue,
+    "iterations": representation.iterations,
+    "hashVersion": representation.hashVersion,
+    "derivedKeyLength": representation.derivedKeyLength
+]
+```
+
+To rebuild the envelope after fetching it:
+
+```swift
+let representation = GestureCredentialEnvelope.Base64Representation(
+    salt: storedSalt,
+    hash: storedHash,
+    kdf: .pbkdf2SHA256,
+    iterations: storedIterations,
+    hashVersion: storedHashVersion,
+    derivedKeyLength: storedDerivedKeyLength
+)
+
+let credential = try GestureCredentialEnvelope(
+    base64Representation: representation
+)
+```
+
+You can also encode and decode JSON directly:
+
+```swift
+let data = try credential.jsonData()
+let decoded = try GestureCredentialEnvelope.fromJSONData(data)
+```
+
+## Backend Responsibilities
+
+Store the envelope fields with the user or profile record your app controls. A Firestore-style document might look like this:
+
+```json
+{
+  "gestureCredential": {
+    "salt": "base64 salt",
+    "hash": "base64 hash",
+    "kdf": "pbkdf2-sha256",
+    "iterations": 600000,
+    "hashVersion": 1,
+    "derivedKeyLength": 32,
+    "updatedAt": "server timestamp"
+  }
+}
+```
+
+Your app or backend should also own:
+
+- Fetching the envelope before presenting `GridAuthenticator(.authenticateCredential(...))`.
+- Saving the envelope returned by `GridAuthenticator(.setCredential(...))`.
+- Enforcing lockouts, rate limits, re-authentication windows, and audit logging.
+- Deciding what a successful gesture unlocks.
+- Protecting reads and writes with your normal account authorization rules.
+- Migrating legacy hashes only after a successful legacy gesture match.
+
+Attackers can read a salt without gaining the gesture. Treat the full credential record as sensitive authenticator material: restrict reads, use TLS, avoid logging it, and expose it only to clients authorized to authenticate that account.
+
+## Legacy Migration
+
+The original package API returned a single unsalted SHA-256 string. The 1.x line keeps those APIs source-compatible and marks them deprecated:
+
+```swift
+GridAuthenticator(.set { legacyHash in
+    // Deprecated: store only while migrating old installations.
+})
+
+GridAuthenticator(.authenticate(expectedHash: legacyHash) { success in
+    // Deprecated: prefer authenticateCredential(credential:).
 })
 ```
 
-## Customization
+For production apps that already have legacy hashes, use `authenticateAndUpgrade`. It verifies the old hash first, then gives your app a v1 envelope to save.
 
-The `GridAuthenticator` view can be customized using the following parameters:
+```swift
+GridAuthenticator(.authenticateAndUpgrade(
+    expectedHash: legacyHash,
+    configuration: .recommended,
+    onCredentialUpgrade: { credential in
+        Task {
+            try await saveCredential(userID, credential)
+            try await deleteLegacyHash(userID)
+        }
+    },
+    completion: { success in
+        if success {
+            openUserWorkspace()
+        }
+    }
+))
+```
 
-- `color`: The primary color of the grid and effects [default: `blue`]
-- `interactionMode`: Choose between `.tap` or `.drag` for pattern input [default: `.drag`]
-- `debug`: Enable or disable debug information display. This adds some additional logging and some debug UI elements [default: `false`]
-- `minimumVertices`: Set the minimum number of points required for a valid pattern (setup mode only) [default: `6`]
-- `requireConfirmation`: User will be asked to confirm their pattern prior to completion being called (setup mode only) [default: `true`]
-- `repeatInput`: The pattern will be repeated back for the user after their initial input and before their confirmation input (setup mode only) [default: `true`]
+This upgrade callback only fires after a successful legacy match. If saving the new credential fails, keep the legacy hash and retry migration on a later successful login.
 
-## Security
+## Security Model
 
-Pattern Authentication uses SHA-256 hashing to securely store and compare patterns. The actual pattern is never stored, only its hash.
+The v1 credential format uses:
+
+- Canonical gesture encoding with a package-specific domain separator.
+- A fresh cryptographically secure random salt per credential.
+- PBKDF2-HMAC-SHA256 with 600,000 iterations by default.
+- 32-byte salts and 32-byte derived hashes by default.
+- Constant-time comparison for hash verification.
+- `Codable`, base64, and JSON helpers for app-controlled storage.
+
+Gesture patterns have limited entropy compared with passwords or passkeys. Use this package for local app re-authentication, profile switching, child or household user gates, or lightweight secondary checks. Do not use a pattern gesture as your only account security boundary for high-value accounts. Pair it with your app's normal signed-in session, backend authorization, attempt limits, and recovery flow.
+
+Argon2id would add memory-hard offline attack resistance. v1 uses PBKDF2-HMAC-SHA256 because Apple platforms provide it without a native dependency, which keeps SwiftPM integration simple.
+
+## Configuration
+
+`setCredential` uses these defaults:
+
+| Parameter | Default | Notes |
+| --- | --- | --- |
+| `minimumVertices` | `6` | Rejects short setup gestures. |
+| `color` | `.blue` | Drives circles, glow, and particles. |
+| `interactionMode` | `.drag` | Drag input is the supported production path. |
+| `requireConfirmation` | `true` | Requires the user to repeat a setup pattern. |
+| `repeatInput` | `true` | Replays the entered pattern by default. |
+| `debug` | `false` | Shows safe diagnostics without printing raw hashes. |
+| `configuration` | `.recommended` | PBKDF2-HMAC-SHA256, 600,000 iterations. |
+
+`InteractionMode.tap` remains for source compatibility and future UI work. Use `.drag` for production flows.
 
 ## Troubleshooting
 
-If you encounter any issues:
+If the particle trail appears offset, check whether a wrapper view overrides the `"GridSpace"` coordinate space. The package draws particles from grid-local geometry captured through SwiftUI preferences.
 
-1. Ensure you're using the latest version of the package.
-2. Check that your iOS deployment target is set to iOS 15.0 or later.
-3. If using the debug mode, verify that the current hash matches the expected hash.
+If the particle trail appears dotted after direct customization, keep `ParticleSystem.emissionSpacing` lower than `ParticleSystem.particleDiameter`. The defaults interpolate fast drag movement and draw fingertip-sized particles so normal swipes read as a continuous trail.
 
-## Contributing
+If authentication always fails, confirm that you are passing the exact fetched `GestureCredentialEnvelope` back into `.authenticateCredential`. Salt, hash, KDF, iteration count, hash version, and derived key length must all match the stored record.
 
-Contributions to the Pattern Authentication package are welcome. Please feel free to submit a Merge Request.
+If migration does not save a v1 credential, check your `onCredentialUpgrade` callback. The package creates the envelope after a successful legacy match; your app writes it to storage.
 
-## Support
+If CI coverage fails, run the same command locally:
 
-For questions, bug reports, or feature requests, please open an issue on the GitHub repository.
+```bash
+xcodebuild test \
+  -scheme PatternAuthentication \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  -enableCodeCoverage YES \
+  -resultBundlePath TestResults.xcresult \
+  SWIFT_VERSION=6 \
+  SWIFT_STRICT_CONCURRENCY=complete
 
-## Roadmap and Known Issues
+xcrun xccov view --report --json TestResults.xcresult > coverage.json
+python3 Scripts/check_coverage.py coverage.json \
+  --threshold 90 \
+  --ignore Sources/PatternAuthentication/PatternAuthentication.swift
+```
 
-- *Known Issue* - `.tap` interaction is not currently activated. Passing the `.tap` will not change the input
-- *Roadmap* - increase size of particles for a wider particle path
+## Versioning
+
+The security credential upgrade adds APIs in 1.x. Deprecated legacy APIs stay available so existing apps can migrate without a breaking release. A future 2.0 release may remove legacy SHA-256 setup/authentication APIs and revisit reserved interaction modes.
+
+See [CHANGELOG.md](CHANGELOG.md) for the full `1.1.0` release notes. See [Docs/MigrationGuide.md](Docs/MigrationGuide.md) and [SECURITY.md](SECURITY.md) for migration and operating guidance.
 
 ## License
 
-Pattern Authentication is available under the MIT license. See the [LICENSE](LICENSE) file for more info.
+Pattern Authentication uses the MIT license. See [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Notes
+
+Pattern Authentication handles the client-side gesture UI and credential derivation/verification. Apps integrating the package remain responsible for backend storage, user identity, sessions, lockout policy, authorization, and audit logging.
+
+## Supported credential format
+
+The v1 credential format uses:
+
+- Canonical gesture encoding with a package domain separator.
+- A fresh secure-random salt for each credential.
+- PBKDF2-HMAC-SHA256 with 600,000 iterations by default.
+- 32-byte salts and 32-byte derived hashes by default.
+- Constant-time hash comparison.
+
+## Storage guidance
+
+Store these fields together:
+
+- `salt`: base64-encoded salt bytes.
+- `hash`: base64-encoded derived hash bytes.
+- `kdf`: currently `pbkdf2-sha256`.
+- `iterations`: currently `600000` by default.
+- `hashVersion`: currently `1`.
+- `derivedKeyLength`: currently `32` by default.
+
+The salt is not secret, but the credential record is sensitive. Restrict reads and writes, use TLS, and avoid logging credential material.
+
+## Operational guidance
+
+- Use gesture authentication as a local or secondary gate, not as the only proof of account ownership for high-value data.
+- Enforce attempt limits and cool-downs in your app or backend.
+- Create sessions and authorize data access through your normal backend checks after a successful gesture match.
+- Provide a recovery flow for forgotten gestures.
+- Migrate legacy SHA-256 hashes only after a successful legacy match.
+
+## Reporting vulnerabilities
+
+Please open a private security advisory or contact the repository owner before disclosing a vulnerability publicly.

--- a/Scripts/check_coverage.py
+++ b/Scripts/check_coverage.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Fail the build when xccov JSON coverage drops below a threshold."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("coverage_json", type=Path)
+    parser.add_argument("--threshold", type=float, default=90.0)
+    parser.add_argument(
+        "--ignore",
+        action="append",
+        default=[],
+        help="Path suffix to exclude from coverage math. Can be passed multiple times.",
+    )
+    parser.add_argument("--target", default="PatternAuthentication")
+    return parser.parse_args()
+
+
+def ignored(path: str, ignored_suffixes: list[str]) -> bool:
+    normalized = path.replace("\\", "/")
+    return any(normalized.endswith(suffix) for suffix in ignored_suffixes)
+
+
+def main() -> int:
+    args = parse_args()
+    report = json.loads(args.coverage_json.read_text())
+    target = next(
+        (item for item in report["targets"] if item.get("name") == args.target),
+        None,
+    )
+    if target is None:
+        raise SystemExit(f"Coverage target {args.target!r} not found.")
+
+    covered = 0
+    executable = 0
+    included_files: list[tuple[str, int, int]] = []
+
+    for file_report in target["files"]:
+        path = file_report["path"]
+        if ignored(path, args.ignore):
+            continue
+        file_covered = int(file_report["coveredLines"])
+        file_executable = int(file_report["executableLines"])
+        covered += file_covered
+        executable += file_executable
+        included_files.append((path, file_covered, file_executable))
+
+    if executable == 0:
+        raise SystemExit("Coverage report contained no executable lines.")
+
+    coverage = (covered / executable) * 100
+    print(f"Coverage for {args.target}: {coverage:.2f}% ({covered}/{executable})")
+    for path, file_covered, file_executable in included_files:
+        file_coverage = (file_covered / file_executable) * 100 if file_executable else 100
+        print(f"  {file_coverage:6.2f}%  {file_covered:4}/{file_executable:<4} {path}")
+
+    if coverage < args.threshold:
+        print(f"Coverage is below required threshold: {coverage:.2f}% < {args.threshold:.2f}%")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Sources/PatternAuthentication/Animations/ParticleSystem.swift
+++ b/Sources/PatternAuthentication/Animations/ParticleSystem.swift
@@ -5,37 +5,168 @@
 //  Created by Shain Mack on 9/17/24.
 //
 import SwiftUI
-import CryptoKit
+#if canImport(UIKit)
+import UIKit
+#endif
 
-public struct Particle: Hashable {
+/// A single path particle rendered in grid-local coordinates.
+public struct Particle: Hashable, Sendable {
+    /// The particle's x-coordinate in the grid canvas coordinate space.
     public let x: Double
+
+    /// The particle's y-coordinate in the grid canvas coordinate space.
     public let y: Double
-    public let creationDate = Date.now.timeIntervalSinceReferenceDate
+
+    /// The reference date used to fade and expire the particle.
+    public let creationDate: TimeInterval
+
+    /// Creates a particle at a canvas-local point.
+    ///
+    /// - Parameters:
+    ///   - x: The x-coordinate in the grid canvas coordinate space.
+    ///   - y: The y-coordinate in the grid canvas coordinate space.
+    ///   - creationDate: The reference date used for aging. Defaults to
+    ///     `Date.now.timeIntervalSinceReferenceDate`.
+    /// - Returns: A particle ready to render.
+    /// - Throws: This initializer does not throw.
+    public init(
+        x: Double,
+        y: Double,
+        creationDate: TimeInterval = Date.now.timeIntervalSinceReferenceDate
+    ) {
+        self.x = x
+        self.y = y
+        self.creationDate = creationDate
+    }
 }
 
-public class ParticleSystem {
+/// Stores and expires gesture path particles for the authenticator canvas.
+///
+/// `ParticleSystem` is main-actor isolated because it owns SwiftUI image state
+/// and is mutated by SwiftUI gesture callbacks and timeline rendering.
+@MainActor
+public final class ParticleSystem {
+    /// The spark image loaded from the SwiftPM resource bundle.
     public let image = Image("spark", bundle: Bundle.module)
+
+    /// The rendered point-size of each particle.
+    public let particleDiameter: CGFloat
+
+    /// The maximum point distance between interpolated particles.
+    public let emissionSpacing: CGFloat
+
+    /// The number of seconds a particle remains visible.
+    public let particleLifetime: TimeInterval
+
+    /// The active particles currently visible in the canvas.
     public var particles = Set<Particle>()
-    public var center = UnitPoint.center
-    
+
+    private var lastEmissionPoint: CGPoint?
+
+    /// Creates an empty particle system.
+    ///
+    /// - Parameters:
+    ///   - particleDiameter: Rendered point-size of each particle. Defaults to
+    ///     `44`, which approximates a fingertip-sized trail on iPhone displays.
+    ///     Values below `1` are clamped to `1`.
+    ///   - emissionSpacing: Maximum point distance between interpolated
+    ///     particles. Defaults to `4`. Values below `1` are clamped to `1`.
+    ///   - particleLifetime: Seconds before a particle expires. Defaults to `1`.
+    ///     Values below `0.1` are clamped to `0.1`.
+    /// - Returns: A particle system with no active particles.
+    /// - Throws: This initializer does not throw.
+    public init(
+        particleDiameter: CGFloat = 44,
+        emissionSpacing: CGFloat = 4,
+        particleLifetime: TimeInterval = 1
+    ) {
+        self.particleDiameter = max(1, particleDiameter)
+        self.emissionSpacing = max(1, emissionSpacing)
+        self.particleLifetime = max(0.1, particleLifetime)
+    }
+
+    /// Removes particles older than ``particleLifetime``.
+    ///
+    /// - Parameter date: The current animation timeline reference date.
+    /// This method does not return a value. It mutates ``particles`` in place.
+    /// - Throws: This method does not throw.
     public func update(date: TimeInterval) {
-        let deathDate = date - 1
-        
+        let deathDate = date - particleLifetime
+
         for particle in particles {
             if particle.creationDate < deathDate {
                 particles.remove(particle)
             }
         }
     }
-    
+
+    /// Clears the previous interpolation anchor without removing visible particles.
+    ///
+    /// This method does not return a value. It prevents a future stroke from
+    /// interpolating back to the last point in a completed stroke.
+    /// - Throws: This method does not throw.
+    public func resetTrail() {
+        lastEmissionPoint = nil
+    }
+
+    /// Adds a particle trail segment ending at a grid-local point.
+    ///
+    /// - Parameter location: The point in the grid canvas coordinate space.
+    /// This method does not return a value. It inserts one or more interpolated
+    /// particles into ``particles`` so fast drag updates render as a continuous
+    /// trail instead of a dotted path.
+    /// - Throws: This method does not throw.
     public func addParticle(at location: CGPoint) {
-        let newParticle = Particle(x: center.x, y: center.y)
+        let creationDate = Date.now.timeIntervalSinceReferenceDate
+        defer { lastEmissionPoint = location }
+
+        guard let lastEmissionPoint else {
+            insertParticle(at: location, creationDate: creationDate)
+            return
+        }
+
+        let distance = hypot(location.x - lastEmissionPoint.x, location.y - lastEmissionPoint.y)
+        guard distance > emissionSpacing, emissionSpacing > 0 else {
+            insertParticle(at: location, creationDate: creationDate)
+            return
+        }
+
+        let steps = max(1, Int(ceil(distance / emissionSpacing)))
+        for step in 1 ... steps {
+            let progress = CGFloat(step) / CGFloat(steps)
+            let interpolatedPoint = CGPoint(
+                x: lastEmissionPoint.x + (location.x - lastEmissionPoint.x) * progress,
+                y: lastEmissionPoint.y + (location.y - lastEmissionPoint.y) * progress
+            )
+            insertParticle(at: interpolatedPoint, creationDate: creationDate)
+        }
+    }
+
+    /// Inserts a single particle without altering interpolation state.
+    ///
+    /// - Parameters:
+    ///   - location: The grid canvas coordinate where the particle is rendered.
+    ///   - creationDate: The reference date used for particle aging.
+    /// This method does not return a value. It mutates ``particles``.
+    /// - Throws: This method does not throw.
+    private func insertParticle(at location: CGPoint, creationDate: TimeInterval) {
+        let newParticle = Particle(x: location.x, y: location.y, creationDate: creationDate)
         particles.insert(newParticle)
     }
 }
 
-public func hashArray(_ array: [Int]) -> String {
-    let data = array.withUnsafeBytes { Data($0) }
-    let hash = SHA256.hash(data: data)
-    return hash.compactMap { String(format: "%02x", $0) }.joined()
+/// Probes bundled resources in tests without exposing resource details publicly.
+enum PatternAuthenticationResourceProbe {
+    /// Whether the SwiftPM bundle can resolve the spark image resource.
+    ///
+    /// - Returns: `true` when the resource exists on UIKit platforms. Non-UIKit
+    ///   platforms return `true` because image probing is unavailable there.
+    @MainActor
+    static var sparkImageExists: Bool {
+        #if canImport(UIKit)
+        UIImage(named: "spark", in: .module, compatibleWith: nil) != nil
+        #else
+        true
+        #endif
+    }
 }

--- a/Sources/PatternAuthentication/Animations/ParticleSystem.swift
+++ b/Sources/PatternAuthentication/Animations/ParticleSystem.swift
@@ -92,12 +92,7 @@ public final class ParticleSystem {
     /// - Throws: This method does not throw.
     public func update(date: TimeInterval) {
         let deathDate = date - particleLifetime
-
-        for particle in particles {
-            if particle.creationDate < deathDate {
-                particles.remove(particle)
-            }
-        }
+        particles = particles.filter { $0.creationDate >= deathDate }
     }
 
     /// Clears the previous interpolation anchor without removing visible particles.

--- a/Sources/PatternAuthentication/Animations/Shake.swift
+++ b/Sources/PatternAuthentication/Animations/Shake.swift
@@ -7,11 +7,42 @@
 
 import SwiftUI
 
+/// A horizontal shake effect used to signal failed gesture attempts.
 public struct Shake: GeometryEffect {
+    /// The maximum horizontal translation in points.
     public var amount: CGFloat = 10
+
+    /// The number of shake oscillations per animation unit.
     public var shakesPerUnit = 3
+
+    /// The animatable value that advances the shake.
     public var animatableData: CGFloat
 
+    /// Creates a shake geometry effect.
+    ///
+    /// - Parameters:
+    ///   - amount: Maximum horizontal translation in points. Defaults to `10`.
+    ///   - shakesPerUnit: Number of oscillations per animation unit. Defaults
+    ///     to `3`.
+    ///   - animatableData: The animatable progress value. Defaults to `0`.
+    /// - Returns: A geometry effect that translates content horizontally.
+    /// - Throws: This initializer does not throw.
+    public init(
+        amount: CGFloat = 10,
+        shakesPerUnit: Int = 3,
+        animatableData: CGFloat = 0
+    ) {
+        self.amount = amount
+        self.shakesPerUnit = shakesPerUnit
+        self.animatableData = animatableData
+    }
+
+    /// Calculates the translation transform for the current shake progress.
+    ///
+    /// - Parameter size: The size of the affected view. The shake effect does
+    ///   not depend on this value.
+    /// - Returns: A projection transform that translates the view on the x-axis.
+    /// - Throws: This method does not throw.
     public func effectValue(size: CGSize) -> ProjectionTransform {
         ProjectionTransform(CGAffineTransform(translationX:
             amount * sin(animatableData * .pi * CGFloat(shakesPerUnit)),

--- a/Sources/PatternAuthentication/Credentials/GestureCredential.swift
+++ b/Sources/PatternAuthentication/Credentials/GestureCredential.swift
@@ -459,8 +459,17 @@ public enum GestureCredentialHasher {
     ///   `expectedHash`; otherwise, `false`.
     /// - Throws: This method does not throw.
     public static func verifyLegacySHA256(vertices: [Int], expectedHash: String) -> Bool {
+        let expectedHashBytes = expectedHash.utf8
+        guard expectedHashBytes.count == 64,
+              expectedHashBytes.allSatisfy({ byte in
+                  (48 ... 57).contains(byte)
+                      || (65 ... 70).contains(byte)
+                      || (97 ... 102).contains(byte)
+              })
+        else { return false }
+
         let actualHash = legacyHashArray(vertices)
-        return constantTimeEquals(Data(actualHash.utf8), Data(expectedHash.utf8))
+        return constantTimeEquals(Data(actualHash.utf8), Data(expectedHash.lowercased().utf8))
     }
 
     /// Creates a v1 envelope after a successful legacy SHA-256 verification.

--- a/Sources/PatternAuthentication/Credentials/GestureCredential.swift
+++ b/Sources/PatternAuthentication/Credentials/GestureCredential.swift
@@ -543,9 +543,9 @@ public enum GestureCredentialHasher {
         iterations: Int,
         derivedKeyLength: Int
     ) throws(GestureCredentialError) -> Data {
-        guard iterations > 0 else {
-            throw .invalidIterationCount(iterations)
-        }
+guard iterations > 0, iterations <= Int(UInt32.max) else {
+    throw .invalidIterationCount(iterations)
+}
         guard derivedKeyLength > 0 else {
             throw .invalidDerivedKeyLength(derivedKeyLength)
         }

--- a/Sources/PatternAuthentication/Credentials/GestureCredential.swift
+++ b/Sources/PatternAuthentication/Credentials/GestureCredential.swift
@@ -1,0 +1,633 @@
+import CommonCrypto
+import Foundation
+import Security
+
+/// A typed error returned while creating, decoding, or verifying gesture credentials.
+///
+/// `GestureCredentialError` is used by the v1 credential APIs so callers can
+/// distinguish malformed input, unsupported credential metadata, random-number
+/// generation failures, and PBKDF2 failures.
+public enum GestureCredentialError: Error, Equatable, Sendable, CustomStringConvertible {
+    /// The gesture pattern did not contain any vertices.
+    case emptyPattern
+
+    /// A gesture vertex was outside the supported 3x3 grid range.
+    case invalidVertex(Int)
+
+    /// The gesture contained more vertices than the canonical encoder can store.
+    case patternTooLong(Int)
+
+    /// The PBKDF2 iteration count was not positive.
+    case invalidIterationCount(Int)
+
+    /// The salt length was outside the supported 16...64 byte range.
+    case invalidSaltLength(Int)
+
+    /// The derived key length was outside the supported 16...64 byte range.
+    case invalidDerivedKeyLength(Int)
+
+    /// The credential version was not positive.
+    case invalidHashVersion(Int)
+
+    /// Secure random byte generation failed.
+    case secureRandomFailed(OSStatus)
+
+    /// The credential requested a key-derivation function this package does not support.
+    case unsupportedKDF(GestureKDF)
+
+    /// CommonCrypto failed while deriving a credential hash.
+    case derivationFailed(Int32)
+
+    /// A base64-encoded credential field could not be decoded.
+    case invalidBase64(field: String)
+
+    /// A human-readable description of the credential error.
+    ///
+    /// - Returns: A diagnostic string suitable for logging or developer-facing
+    ///   troubleshooting. It is not localized.
+    public var description: String {
+        switch self {
+        case .emptyPattern:
+            "A gesture pattern must contain at least one vertex."
+        case let .invalidVertex(vertex):
+            "Gesture vertex \(vertex) is outside the supported 3x3 grid range."
+        case let .patternTooLong(count):
+            "Gesture pattern length \(count) exceeds the supported canonical encoding length."
+        case let .invalidIterationCount(iterations):
+            "PBKDF2 iteration count must be positive, got \(iterations)."
+        case let .invalidSaltLength(length):
+            "Salt length must be between 16 and 64 bytes, got \(length)."
+        case let .invalidDerivedKeyLength(length):
+            "Derived key length must be between 16 and 64 bytes, got \(length)."
+        case let .invalidHashVersion(version):
+            "Hash version must be positive, got \(version)."
+        case let .secureRandomFailed(status):
+            "Secure random salt generation failed with OSStatus \(status)."
+        case let .unsupportedKDF(kdf):
+            "Unsupported gesture KDF: \(kdf.rawValue)."
+        case let .derivationFailed(status):
+            "PBKDF2 derivation failed with status \(status)."
+        case let .invalidBase64(field):
+            "Credential field \(field) is not valid base64."
+        }
+    }
+}
+
+/// A supported key-derivation algorithm for gesture credentials.
+///
+/// The v1 credential format currently supports PBKDF2-HMAC-SHA256. The enum is
+/// persisted in credentials so future versions can add algorithms without
+/// changing the envelope shape.
+public enum GestureKDF: String, Codable, CaseIterable, Sendable {
+    /// PBKDF2 using HMAC-SHA256.
+    case pbkdf2SHA256 = "pbkdf2-sha256"
+}
+
+/// Configuration used when creating a new gesture credential.
+public struct GestureHashConfiguration: Codable, Equatable, Sendable {
+    /// The default configuration for new v1 gesture credentials.
+    ///
+    /// - Returns: A PBKDF2-HMAC-SHA256 configuration with 600,000 iterations,
+    ///   32 bytes of salt, a 32-byte derived key, and hash version `1`.
+    public static let recommended = GestureHashConfiguration()
+
+    /// The key-derivation algorithm used to derive the credential hash.
+    public let kdf: GestureKDF
+
+    /// The PBKDF2 iteration count.
+    public let iterations: Int
+
+    /// The number of random salt bytes to generate for each credential.
+    public let saltLength: Int
+
+    /// The number of bytes produced by the key-derivation function.
+    public let derivedKeyLength: Int
+
+    /// The version marker stored with new credentials.
+    public let hashVersion: Int
+
+    /// Creates a credential hashing configuration.
+    ///
+    /// - Parameters:
+    ///   - kdf: The key-derivation algorithm. Defaults to `.pbkdf2SHA256`.
+    ///   - iterations: The PBKDF2 iteration count. Defaults to `600_000`.
+    ///   - saltLength: The random salt length in bytes. Defaults to `32`.
+    ///   - derivedKeyLength: The derived key length in bytes. Defaults to `32`.
+    ///   - hashVersion: The credential hash version to write. Defaults to `1`.
+    /// - Returns: A value describing how new gesture credentials should be
+    ///   derived.
+    /// - Throws: This initializer does not throw. Values are validated when a
+    ///   credential is created.
+    public init(
+        kdf: GestureKDF = .pbkdf2SHA256,
+        iterations: Int = 600_000,
+        saltLength: Int = 32,
+        derivedKeyLength: Int = 32,
+        hashVersion: Int = 1
+    ) {
+        self.kdf = kdf
+        self.iterations = iterations
+        self.saltLength = saltLength
+        self.derivedKeyLength = derivedKeyLength
+        self.hashVersion = hashVersion
+    }
+}
+
+/// A validated 3x3-grid gesture pattern.
+public struct GesturePattern: Codable, Equatable, Hashable, Sendable {
+    /// The ordered vertex indices selected by the user.
+    ///
+    /// Vertices are zero-based indices in a 3x3 grid and must be in the range
+    /// `0...8`.
+    public let vertices: [Int]
+
+    /// Creates a validated gesture pattern.
+    ///
+    /// - Parameter vertices: Ordered 3x3 grid vertex indices in the range
+    ///   `0...8`.
+    /// - Returns: A validated gesture pattern ready for canonical encoding.
+    /// - Throws: ``GestureCredentialError/emptyPattern`` when `vertices` is
+    ///   empty, ``GestureCredentialError/patternTooLong(_:)`` when the pattern
+    ///   is too long to encode, or ``GestureCredentialError/invalidVertex(_:)``
+    ///   when any index is outside `0...8`.
+    public init(_ vertices: [Int]) throws(GestureCredentialError) {
+        guard !vertices.isEmpty else {
+            throw .emptyPattern
+        }
+        guard vertices.count <= Int(UInt16.max) else {
+            throw .patternTooLong(vertices.count)
+        }
+        for vertex in vertices where !(0 ... 8).contains(vertex) {
+            throw .invalidVertex(vertex)
+        }
+        self.vertices = vertices
+    }
+
+    /// Stable v1 binary representation used as PBKDF2 input.
+    ///
+    /// - Returns: Canonical bytes containing a domain separator, the big-endian
+    ///   vertex count, and the ordered vertex bytes.
+    public var canonicalData: Data {
+        var data = Data("PatternAuthentication.GesturePattern.v1".utf8)
+        data.append(0)
+
+        var count = UInt16(vertices.count).bigEndian
+        withUnsafeBytes(of: &count) { bytes in
+            data.append(contentsOf: bytes)
+        }
+
+        data.append(contentsOf: vertices.map { UInt8($0) })
+        return data
+    }
+}
+
+/// A salted, versioned gesture credential suitable for app-controlled storage.
+public struct GestureCredentialEnvelope: Codable, Equatable, Hashable, Sendable {
+    /// The random salt used when deriving ``hash``.
+    public let salt: Data
+
+    /// The derived credential hash.
+    public let hash: Data
+
+    /// The key-derivation algorithm used to create ``hash``.
+    public let kdf: GestureKDF
+
+    /// The iteration count used to create ``hash``.
+    public let iterations: Int
+
+    /// The version marker for this credential format.
+    public let hashVersion: Int
+
+    /// The expected byte length of ``hash``.
+    public let derivedKeyLength: Int
+
+    /// Creates a credential envelope from already-derived credential material.
+    ///
+    /// Use `GestureCredentialHasher.createCredential(for:configuration:)` for
+    /// normal setup. This initializer is intended for decoding, tests, and
+    /// backend-provided credential material.
+    ///
+    /// - Parameters:
+    ///   - salt: The salt bytes stored with the credential.
+    ///   - hash: The derived credential hash bytes.
+    ///   - kdf: The key-derivation algorithm used for `hash`. No default.
+    ///   - iterations: The iteration count used for `hash`. No default.
+    ///   - hashVersion: The credential version. No default.
+    ///   - derivedKeyLength: The expected `hash` byte count. No default.
+    /// - Returns: A credential envelope containing the supplied material.
+    /// - Throws: This initializer does not throw. Credential metadata is
+    ///   validated by verification APIs.
+    public init(
+        salt: Data,
+        hash: Data,
+        kdf: GestureKDF,
+        iterations: Int,
+        hashVersion: Int,
+        derivedKeyLength: Int
+    ) {
+        self.salt = salt
+        self.hash = hash
+        self.kdf = kdf
+        self.iterations = iterations
+        self.hashVersion = hashVersion
+        self.derivedKeyLength = derivedKeyLength
+    }
+
+    /// A storage-friendly representation for systems that prefer base64 strings.
+    public struct Base64Representation: Codable, Equatable, Hashable, Sendable {
+        /// The base64-encoded salt bytes.
+        public let salt: String
+
+        /// The base64-encoded derived hash bytes.
+        public let hash: String
+
+        /// The key-derivation algorithm used to create ``hash``.
+        public let kdf: GestureKDF
+
+        /// The iteration count used to create ``hash``.
+        public let iterations: Int
+
+        /// The credential version marker.
+        public let hashVersion: Int
+
+        /// The expected decoded byte count of ``hash``.
+        public let derivedKeyLength: Int
+
+        /// Creates a base64 credential representation.
+        ///
+        /// - Parameters:
+        ///   - salt: Base64-encoded salt bytes. No default.
+        ///   - hash: Base64-encoded derived hash bytes. No default.
+        ///   - kdf: The key-derivation algorithm used for `hash`. No default.
+        ///   - iterations: The iteration count used for `hash`. No default.
+        ///   - hashVersion: The credential version. No default.
+        ///   - derivedKeyLength: The expected decoded `hash` byte count. No
+        ///     default.
+        /// - Returns: A storage-friendly credential representation.
+        /// - Throws: This initializer does not throw. Base64 strings are decoded
+        ///   by ``GestureCredentialEnvelope/init(base64Representation:)``.
+        public init(
+            salt: String,
+            hash: String,
+            kdf: GestureKDF,
+            iterations: Int,
+            hashVersion: Int,
+            derivedKeyLength: Int
+        ) {
+            self.salt = salt
+            self.hash = hash
+            self.kdf = kdf
+            self.iterations = iterations
+            self.hashVersion = hashVersion
+            self.derivedKeyLength = derivedKeyLength
+        }
+    }
+
+    /// The envelope as base64 strings for JSON-friendly storage.
+    ///
+    /// - Returns: A representation with base64-encoded `salt` and `hash`
+    ///   fields and unchanged credential metadata.
+    public var base64Representation: Base64Representation {
+        Base64Representation(
+            salt: salt.base64EncodedString(),
+            hash: hash.base64EncodedString(),
+            kdf: kdf,
+            iterations: iterations,
+            hashVersion: hashVersion,
+            derivedKeyLength: derivedKeyLength
+        )
+    }
+
+    /// Creates a credential envelope from a base64 representation.
+    ///
+    /// - Parameter base64Representation: The representation containing
+    ///   base64-encoded `salt` and `hash` fields.
+    /// - Returns: A credential envelope with decoded binary salt and hash data.
+    /// - Throws: ``GestureCredentialError/invalidBase64(field:)`` when either
+    ///   `salt` or `hash` is not valid base64.
+    public init(base64Representation: Base64Representation) throws(GestureCredentialError) {
+        guard let salt = Data(base64Encoded: base64Representation.salt) else {
+            throw .invalidBase64(field: "salt")
+        }
+        guard let hash = Data(base64Encoded: base64Representation.hash) else {
+            throw .invalidBase64(field: "hash")
+        }
+        self.init(
+            salt: salt,
+            hash: hash,
+            kdf: base64Representation.kdf,
+            iterations: base64Representation.iterations,
+            hashVersion: base64Representation.hashVersion,
+            derivedKeyLength: base64Representation.derivedKeyLength
+        )
+    }
+
+    /// Encodes the base64 representation as JSON for local storage or transport.
+    ///
+    /// - Parameter encoder: The JSON encoder used to encode the base64
+    ///   representation. Defaults to `JSONEncoder()`.
+    /// - Returns: JSON bytes containing the base64 representation.
+    /// - Throws: Any error thrown by `encoder`.
+    public func jsonData(encoder: JSONEncoder = JSONEncoder()) throws -> Data {
+        try encoder.encode(base64Representation)
+    }
+
+    /// Decodes an envelope from JSON produced by ``jsonData(encoder:)``.
+    ///
+    /// - Parameters:
+    ///   - data: JSON bytes containing a ``Base64Representation``.
+    ///   - decoder: The JSON decoder used to decode `data`. Defaults to
+    ///     `JSONDecoder()`.
+    /// - Returns: A credential envelope decoded from the JSON payload.
+    /// - Throws: Any error thrown by `decoder`, or
+    ///   ``GestureCredentialError/invalidBase64(field:)`` when the decoded
+    ///   representation contains invalid base64.
+    public static func fromJSONData(
+        _ data: Data,
+        decoder: JSONDecoder = JSONDecoder()
+    ) throws -> GestureCredentialEnvelope {
+        let representation = try decoder.decode(Base64Representation.self, from: data)
+        return try GestureCredentialEnvelope(base64Representation: representation)
+    }
+}
+
+/// Creates and verifies gesture credential envelopes.
+public enum GestureCredentialHasher {
+    /// Creates a salted v1 credential for a raw vertex array.
+    ///
+    /// - Parameters:
+    ///   - vertices: Ordered 3x3 grid vertex indices in the range `0...8`.
+    ///   - configuration: The hashing configuration to use. Defaults to
+    ///     ``GestureHashConfiguration/recommended``.
+    /// - Returns: A new credential envelope with a fresh random salt.
+    /// - Throws: A ``GestureCredentialError`` when the pattern or configuration
+    ///   is invalid, random salt generation fails, or PBKDF2 derivation fails.
+    public static func createCredential(
+        for vertices: [Int],
+        configuration: GestureHashConfiguration = .recommended
+    ) throws(GestureCredentialError) -> GestureCredentialEnvelope {
+        let pattern = try GesturePattern(vertices)
+        return try createCredential(for: pattern, configuration: configuration)
+    }
+
+    /// Creates a salted v1 credential for a validated gesture pattern.
+    ///
+    /// - Parameters:
+    ///   - pattern: The validated gesture pattern to encode and hash.
+    ///   - configuration: The hashing configuration to use. Defaults to
+    ///     ``GestureHashConfiguration/recommended``.
+    /// - Returns: A new credential envelope with a fresh random salt.
+    /// - Throws: A ``GestureCredentialError`` when the configuration is invalid,
+    ///   random salt generation fails, or PBKDF2 derivation fails.
+    public static func createCredential(
+        for pattern: GesturePattern,
+        configuration: GestureHashConfiguration = .recommended
+    ) throws(GestureCredentialError) -> GestureCredentialEnvelope {
+        try validate(configuration: configuration)
+        let salt = try secureRandomData(count: configuration.saltLength)
+        let hash = try deriveKey(
+            password: pattern.canonicalData,
+            salt: salt,
+            kdf: configuration.kdf,
+            iterations: configuration.iterations,
+            derivedKeyLength: configuration.derivedKeyLength
+        )
+        return GestureCredentialEnvelope(
+            salt: salt,
+            hash: hash,
+            kdf: configuration.kdf,
+            iterations: configuration.iterations,
+            hashVersion: configuration.hashVersion,
+            derivedKeyLength: configuration.derivedKeyLength
+        )
+    }
+
+    /// Verifies a raw vertex array against a stored credential envelope.
+    ///
+    /// - Parameters:
+    ///   - vertices: Ordered 3x3 grid vertex indices in the range `0...8`.
+    ///   - credential: The stored credential envelope fetched by the app.
+    /// - Returns: `true` when `vertices` derive the stored credential hash;
+    ///   otherwise, `false`.
+    /// - Throws: A ``GestureCredentialError`` when the pattern or credential
+    ///   metadata is invalid, or PBKDF2 derivation fails.
+    public static func verify(
+        vertices: [Int],
+        against credential: GestureCredentialEnvelope
+    ) throws(GestureCredentialError) -> Bool {
+        let pattern = try GesturePattern(vertices)
+        return try verify(pattern, against: credential)
+    }
+
+    /// Verifies a validated gesture pattern against a stored credential envelope.
+    ///
+    /// - Parameters:
+    ///   - pattern: The validated gesture pattern to verify.
+    ///   - credential: The stored credential envelope fetched by the app.
+    /// - Returns: `true` when `pattern` derives the stored credential hash;
+    ///   otherwise, `false`.
+    /// - Throws: A ``GestureCredentialError`` when the credential metadata is
+    ///   invalid or PBKDF2 derivation fails.
+    public static func verify(
+        _ pattern: GesturePattern,
+        against credential: GestureCredentialEnvelope
+    ) throws(GestureCredentialError) -> Bool {
+        try validate(credential: credential)
+        let derivedHash = try deriveKey(
+            password: pattern.canonicalData,
+            salt: credential.salt,
+            kdf: credential.kdf,
+            iterations: credential.iterations,
+            derivedKeyLength: credential.derivedKeyLength
+        )
+        return constantTimeEquals(derivedHash, credential.hash)
+    }
+
+    /// Verifies the package's original SHA-256 string hash format.
+    ///
+    /// - Parameters:
+    ///   - vertices: Ordered 3x3 grid vertex indices to hash using the legacy
+    ///     algorithm.
+    ///   - expectedHash: The legacy hexadecimal SHA-256 hash string to compare
+    ///     against.
+    /// - Returns: `true` when the legacy hash of `vertices` matches
+    ///   `expectedHash`; otherwise, `false`.
+    /// - Throws: This method does not throw.
+    public static func verifyLegacySHA256(vertices: [Int], expectedHash: String) -> Bool {
+        let actualHash = legacyHashArray(vertices)
+        return constantTimeEquals(Data(actualHash.utf8), Data(expectedHash.utf8))
+    }
+
+    /// Creates a v1 envelope after a successful legacy SHA-256 verification.
+    ///
+    /// - Parameters:
+    ///   - vertices: Ordered 3x3 grid vertex indices to verify and migrate.
+    ///   - expectedHash: The existing legacy hexadecimal SHA-256 hash string.
+    ///   - configuration: The hashing configuration for the new v1 credential.
+    ///     Defaults to ``GestureHashConfiguration/recommended``.
+    /// - Returns: A new v1 credential envelope when legacy verification
+    ///   succeeds, or `nil` when the legacy hash does not match.
+    /// - Throws: A ``GestureCredentialError`` when the new credential cannot be
+    ///   created.
+    public static func upgradeLegacyCredential(
+        vertices: [Int],
+        expectedHash: String,
+        configuration: GestureHashConfiguration = .recommended
+    ) throws(GestureCredentialError) -> GestureCredentialEnvelope? {
+        guard verifyLegacySHA256(vertices: vertices, expectedHash: expectedHash) else {
+            return nil
+        }
+        return try createCredential(for: vertices, configuration: configuration)
+    }
+
+    /// Compares two byte buffers in constant time with respect to content.
+    ///
+    /// The loop always examines the length of the longer input and folds the
+    /// length difference into the result.
+    ///
+    /// - Parameters:
+    ///   - lhs: The first byte buffer.
+    ///   - rhs: The second byte buffer.
+    /// - Returns: `true` when both buffers have the same bytes and length;
+    ///   otherwise, `false`.
+    /// - Throws: This method does not throw.
+    public static func constantTimeEquals(_ lhs: Data, _ rhs: Data) -> Bool {
+        let lhsBytes = [UInt8](lhs)
+        let rhsBytes = [UInt8](rhs)
+        let maxCount = max(lhsBytes.count, rhsBytes.count)
+        var difference = lhsBytes.count ^ rhsBytes.count
+
+        for index in 0 ..< maxCount {
+            let left = index < lhsBytes.count ? lhsBytes[index] : 0
+            let right = index < rhsBytes.count ? rhsBytes[index] : 0
+            difference |= Int(left ^ right)
+        }
+
+        return difference == 0
+    }
+
+    /// Derives a key using the supplied key-derivation metadata.
+    ///
+    /// - Parameters:
+    ///   - password: The canonical gesture bytes used as the PBKDF2 password.
+    ///   - salt: The salt bytes used by PBKDF2.
+    ///   - kdf: The key-derivation algorithm. No default.
+    ///   - iterations: The PBKDF2 iteration count. No default.
+    ///   - derivedKeyLength: The number of bytes to derive. No default.
+    /// - Returns: The derived key bytes.
+    /// - Throws: ``GestureCredentialError/invalidIterationCount(_:)`` when
+    ///   `iterations` is not positive,
+    ///   ``GestureCredentialError/invalidDerivedKeyLength(_:)`` when
+    ///   `derivedKeyLength` is not positive,
+    ///   ``GestureCredentialError/unsupportedKDF(_:)`` when `kdf` is not
+    ///   supported, or ``GestureCredentialError/derivationFailed(_:)`` when
+    ///   CommonCrypto fails.
+    static func deriveKey(
+        password: Data,
+        salt: Data,
+        kdf: GestureKDF,
+        iterations: Int,
+        derivedKeyLength: Int
+    ) throws(GestureCredentialError) -> Data {
+        guard iterations > 0 else {
+            throw .invalidIterationCount(iterations)
+        }
+        guard derivedKeyLength > 0 else {
+            throw .invalidDerivedKeyLength(derivedKeyLength)
+        }
+        guard kdf == .pbkdf2SHA256 else {
+            throw .unsupportedKDF(kdf)
+        }
+
+        var derivedKey = Data(repeating: 0, count: derivedKeyLength)
+        let status = password.withUnsafeBytes { passwordBytes in
+            salt.withUnsafeBytes { saltBytes in
+                derivedKey.withUnsafeMutableBytes { derivedKeyBytes in
+                    CCKeyDerivationPBKDF(
+                        CCPBKDFAlgorithm(kCCPBKDF2),
+                        passwordBytes.bindMemory(to: Int8.self).baseAddress,
+                        password.count,
+                        saltBytes.bindMemory(to: UInt8.self).baseAddress,
+                        salt.count,
+                        CCPseudoRandomAlgorithm(kCCPRFHmacAlgSHA256),
+                        UInt32(iterations),
+                        derivedKeyBytes.bindMemory(to: UInt8.self).baseAddress,
+                        derivedKeyLength
+                    )
+                }
+            }
+        }
+
+        guard status == kCCSuccess else {
+            throw .derivationFailed(status)
+        }
+        return derivedKey
+    }
+
+    /// Validates a credential creation configuration.
+    ///
+    /// - Parameter configuration: The configuration to validate.
+    /// If validation succeeds, this method returns normally without producing a
+    /// value.
+    /// - Throws: A ``GestureCredentialError`` when iteration count, salt length,
+    ///   derived key length, or hash version is outside the supported range.
+    private static func validate(
+        configuration: GestureHashConfiguration
+    ) throws(GestureCredentialError) {
+        guard configuration.iterations > 0 else {
+            throw .invalidIterationCount(configuration.iterations)
+        }
+        guard (16 ... 64).contains(configuration.saltLength) else {
+            throw .invalidSaltLength(configuration.saltLength)
+        }
+        guard (16 ... 64).contains(configuration.derivedKeyLength) else {
+            throw .invalidDerivedKeyLength(configuration.derivedKeyLength)
+        }
+        guard configuration.hashVersion > 0 else {
+            throw .invalidHashVersion(configuration.hashVersion)
+        }
+    }
+
+    /// Validates a stored credential envelope before verification.
+    ///
+    /// - Parameter credential: The credential envelope to validate.
+    /// If validation succeeds, this method returns normally without producing a
+    /// value.
+    /// - Throws: A ``GestureCredentialError`` when iteration count, salt length,
+    ///   derived key length, hash byte count, or hash version is outside the
+    ///   supported range.
+    private static func validate(
+        credential: GestureCredentialEnvelope
+    ) throws(GestureCredentialError) {
+        guard credential.iterations > 0 else {
+            throw .invalidIterationCount(credential.iterations)
+        }
+        guard (16 ... 64).contains(credential.salt.count) else {
+            throw .invalidSaltLength(credential.salt.count)
+        }
+        guard (16 ... 64).contains(credential.derivedKeyLength) else {
+            throw .invalidDerivedKeyLength(credential.derivedKeyLength)
+        }
+        guard credential.hash.count == credential.derivedKeyLength else {
+            throw .invalidDerivedKeyLength(credential.hash.count)
+        }
+        guard credential.hashVersion > 0 else {
+            throw .invalidHashVersion(credential.hashVersion)
+        }
+    }
+
+    /// Generates cryptographically secure random bytes.
+    ///
+    /// - Parameter count: The number of random bytes to generate.
+    /// - Returns: A `Data` value containing `count` bytes.
+    /// - Throws: ``GestureCredentialError/secureRandomFailed(_:)`` when
+    ///   Security framework random generation fails.
+    private static func secureRandomData(count: Int) throws(GestureCredentialError) -> Data {
+        var bytes = [UInt8](repeating: 0, count: count)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        guard status == errSecSuccess else {
+            throw .secureRandomFailed(status)
+        }
+        return Data(bytes)
+    }
+}

--- a/Sources/PatternAuthentication/Credentials/GestureCredential.swift
+++ b/Sources/PatternAuthentication/Credentials/GestureCredential.swift
@@ -26,6 +26,9 @@ public enum GestureCredentialError: Error, Equatable, Sendable, CustomStringConv
     /// The derived key length was outside the supported 16...64 byte range.
     case invalidDerivedKeyLength(Int)
 
+    /// The stored hash byte count did not match the envelope's derived key length.
+    case hashLengthMismatch(expected: Int, actual: Int)
+
     /// The credential version was not positive.
     case invalidHashVersion(Int)
 
@@ -59,6 +62,8 @@ public enum GestureCredentialError: Error, Equatable, Sendable, CustomStringConv
             "Salt length must be between 16 and 64 bytes, got \(length)."
         case let .invalidDerivedKeyLength(length):
             "Derived key length must be between 16 and 64 bytes, got \(length)."
+        case let .hashLengthMismatch(expected, actual):
+            "Credential hash length \(actual) does not match derived key length \(expected)."
         case let .invalidHashVersion(version):
             "Hash version must be positive, got \(version)."
         case let .secureRandomFailed(status):
@@ -594,8 +599,7 @@ public enum GestureCredentialHasher {
     /// If validation succeeds, this method returns normally without producing a
     /// value.
     /// - Throws: A ``GestureCredentialError`` when iteration count, salt length,
-    ///   derived key length, hash byte count, or hash version is outside the
-    ///   supported range.
+    ///   derived key length, hash byte count, or hash version is invalid.
     private static func validate(
         credential: GestureCredentialEnvelope
     ) throws(GestureCredentialError) {
@@ -609,7 +613,10 @@ public enum GestureCredentialHasher {
             throw .invalidDerivedKeyLength(credential.derivedKeyLength)
         }
         guard credential.hash.count == credential.derivedKeyLength else {
-            throw .invalidDerivedKeyLength(credential.hash.count)
+            throw .hashLengthMismatch(
+                expected: credential.derivedKeyLength,
+                actual: credential.hash.count
+            )
         }
         guard credential.hashVersion > 0 else {
             throw .invalidHashVersion(credential.hashVersion)

--- a/Sources/PatternAuthentication/Credentials/LegacyPatternHash.swift
+++ b/Sources/PatternAuthentication/Credentials/LegacyPatternHash.swift
@@ -1,0 +1,27 @@
+import CryptoKit
+import Foundation
+
+/// Returns the original package SHA-256 hash for a pattern.
+///
+/// This format is retained only for backwards compatibility with existing
+/// stored hashes. New integrations should use ``GestureCredentialEnvelope``.
+///
+/// - Parameter array: Ordered 3x3 grid vertex indices.
+/// - Returns: A lowercase hexadecimal SHA-256 hash of the legacy in-memory
+///   integer-array bytes.
+/// - Throws: This function does not throw.
+@available(*, deprecated, message: "Use GestureCredentialHasher.createCredential(for:) instead.")
+public func hashArray(_ array: [Int]) -> String {
+    legacyHashArray(array)
+}
+
+/// Computes the package's original SHA-256 pattern hash.
+///
+/// - Parameter array: Ordered 3x3 grid vertex indices.
+/// - Returns: A lowercase hexadecimal SHA-256 hash matching v0 package output.
+/// - Throws: This function does not throw.
+func legacyHashArray(_ array: [Int]) -> String {
+    let data = array.withUnsafeBytes { Data($0) }
+    let hash = SHA256.hash(data: data)
+    return hash.compactMap { String(format: "%02x", $0) }.joined()
+}

--- a/Sources/PatternAuthentication/GridAuthenticatorViewModel.swift
+++ b/Sources/PatternAuthentication/GridAuthenticatorViewModel.swift
@@ -589,10 +589,11 @@ public class GridAuthenticatorViewModel: ObservableObject {
     /// Clears setup state after a setup attempt completes.
     ///
     /// This method does not return a value. It clears the selected pattern and
-    /// unlocks input.
+    /// first pattern hash, then unlocks input.
     /// - Throws: This method does not throw.
     private func finishSetup() {
         selectedCardsIndices = []
+        firstPatternHash = nil
         locked = false
     }
 

--- a/Sources/PatternAuthentication/GridAuthenticatorViewModel.swift
+++ b/Sources/PatternAuthentication/GridAuthenticatorViewModel.swift
@@ -7,34 +7,111 @@
 
 import SwiftUI
 
+/// Coordinates gesture input, setup, authentication, replay, and visual state.
+///
+/// `GridAuthenticatorViewModel` is the imperative model behind
+/// `GridAuthenticator`. It is isolated to the main actor because it owns
+/// SwiftUI-observed state and animation state.
+@MainActor
 public class GridAuthenticatorViewModel: ObservableObject {
+    /// The ordered 3x3 grid indices selected during the current gesture.
     @Published public var selectedCardsIndices: [Int] = []
+
+    /// Geometry captured from each grid circle in the grid coordinate space.
     @Published public var cardsData: [CardPreferenceData] = []
+
+    /// The particle system used to render drag and replay particles.
     @Published public var particleSystem = ParticleSystem()
+
+    /// Whether the current gesture is locked while setup confirmation is pending.
     @Published public var locked: Bool = false
+
+    /// The primary color used by the grid, glow, and particles.
     @Published public var viewColor: Color
+
+    /// Whether developer diagnostics should be shown in the view.
     @Published public var debug: Bool
+
+    /// The high-level mode for this authenticator instance.
     public var mode: AuthType
+
+    /// Whether the most recent authentication attempt failed.
     @Published public var incorrectHash: Bool?
+
+    /// The input style expected by this authenticator.
     @Published public var interactionMode: InteractionMode
+
+    /// The number of failed attempts used to drive the shake animation.
     @Published public var incorrectCount: Int = 0
+
+    /// Whether setup should replay the entered gesture after input.
     @Published public var repeatInput: Bool?
+
+    /// Whether setup requires the user to enter the same gesture twice.
     @Published public var requireConfirmation: Bool?
+
+    /// The legacy v0 SHA-256 hash used by deprecated authentication APIs.
     @Published public var expectedHash: String?
+
+    /// The v1 salted credential envelope used by credential authentication APIs.
+    @Published public var expectedCredential: GestureCredentialEnvelope?
+
+    /// The minimum number of vertices required during setup.
     public var minimumVertices: Int? = 6
+
+    /// The hashing configuration used when creating or upgrading v1 credentials.
+    public var hashConfiguration: GestureHashConfiguration = .recommended
+
+    /// Callback invoked after authentication succeeds or fails.
     @Published public var authCompletion: ((Bool) -> Void)?
+
+    /// Callback invoked by deprecated setup APIs with a legacy v0 hash.
     @Published public var setupCompletion: ((String) -> Void)?
+
+    /// Callback invoked by v1 setup APIs with a credential envelope.
+    @Published public var credentialSetupCompletion: ((GestureCredentialEnvelope) -> Void)?
+
+    /// Callback invoked after successful legacy authentication creates a v1 credential.
+    @Published public var legacyUpgradeCompletion: ((GestureCredentialEnvelope) -> Void)?
+
+    /// The setup confirmation state.
     @Published public var confirmationState: ConfirmationState = .initial
+
+    /// The legacy hash of the first setup pattern when confirmation is required.
     @Published public var firstPatternHash: String?
+
+    /// Whether an entered pattern is currently being replayed.
     @Published public var isSimulating: Bool = false
     private var simulationTask: Task<Void, Never>?
+
+    /// Whether the user currently has an active drag gesture.
     @Published public var isDragging: Bool = false
+
+    /// The most recent user-facing validation or credential error.
     @Published public var lastDragError: String?
 
+    /// The last selected grid index in the current gesture.
+    ///
+    /// - Returns: The most recent selected vertex, or `nil` when no vertices
+    ///   are selected.
     public var mostRecentSelection: Int? {
-        return selectedCardsIndices.last
+        selectedCardsIndices.last
     }
 
+    /// The captured centers of the currently selected cards.
+    ///
+    /// - Returns: The selected card centers in selection order, omitting any
+    ///   indices whose geometry has not yet been reported by SwiftUI.
+    public var selectedCardCenters: [CGPoint] {
+        selectedCardsIndices.compactMap { center(for: $0) }
+    }
+
+    /// Creates a view model for one setup or authentication flow.
+    ///
+    /// - Parameter authOption: The setup or authentication option that
+    ///   configures mode, defaults, expected credential material, and callbacks.
+    /// - Returns: A main-actor view model configured for `authOption`.
+    /// - Throws: This initializer does not throw.
     public init(_ authOption: GridAuthenticatorOption) {
         switch authOption {
         case let .authenticate(expectedHash, color, interactionMode, debug, completion):
@@ -44,6 +121,25 @@ public class GridAuthenticatorViewModel: ObservableObject {
             self.debug = debug
             mode = .authenticate
             authCompletion = completion
+
+        case let .authenticateAndUpgrade(expectedHash, color, interactionMode, debug, configuration, onCredentialUpgrade, completion):
+            self.expectedHash = expectedHash
+            viewColor = color
+            self.interactionMode = interactionMode
+            self.debug = debug
+            hashConfiguration = configuration
+            mode = .authenticate
+            legacyUpgradeCompletion = onCredentialUpgrade
+            authCompletion = completion
+
+        case let .authenticateCredential(credential, color, interactionMode, debug, completion):
+            expectedCredential = credential
+            viewColor = color
+            self.interactionMode = interactionMode
+            self.debug = debug
+            mode = .authenticate
+            authCompletion = completion
+
         case let .set(minimumVertices, color, interactionMode, requireConfirmation, repeatInput, debug, completion):
             self.minimumVertices = minimumVertices
             self.repeatInput = repeatInput
@@ -53,17 +149,40 @@ public class GridAuthenticatorViewModel: ObservableObject {
             self.debug = debug
             mode = .set
             setupCompletion = completion
+
+        case let .setCredential(minimumVertices, color, interactionMode, requireConfirmation, repeatInput, debug, configuration, completion):
+            self.minimumVertices = minimumVertices
+            self.repeatInput = repeatInput
+            viewColor = color
+            self.interactionMode = interactionMode
+            self.requireConfirmation = requireConfirmation
+            self.debug = debug
+            hashConfiguration = configuration
+            mode = .set
+            credentialSetupCompletion = completion
         }
     }
 
+    /// The legacy v0 hash for the current gesture selection.
+    ///
+    /// - Returns: A hexadecimal SHA-256 hash produced by the legacy hash
+    ///   algorithm.
     public var currentHash: String {
-        return hashArray(selectedCardsIndices)
+        legacyHashArray(selectedCardsIndices)
     }
 
+    /// Whether the current gesture satisfies the configured minimum length.
+    ///
+    /// - Returns: `true` when `selectedCardsIndices.count` is greater than or
+    ///   equal to ``minimumVertices``; otherwise, `false`.
     public var valid: Bool {
-        return selectedCardsIndices.count >= minimumVertices ?? .max
+        selectedCardsIndices.count >= (minimumVertices ?? .max)
     }
 
+    /// The validation text currently safe to show to the user.
+    ///
+    /// - Returns: An empty string while dragging, then the latest validation
+    ///   message after drag end.
     public var validityText: String {
         if isDragging {
             return ""
@@ -71,155 +190,201 @@ public class GridAuthenticatorViewModel: ObservableObject {
         return lastDragError ?? ""
     }
 
+    /// Handles an in-progress drag gesture over the grid.
+    ///
+    /// - Parameter drag: The SwiftUI drag value whose `location` is expressed
+    ///   in the grid coordinate space.
+    /// The method does not return a value. It mutates selected vertices and
+    /// particle state.
+    /// - Throws: This method does not throw.
     public func duringDrag(drag: DragGesture.Value) {
+        let wasDragging = isDragging
         isDragging = true
-        if !locked {
-            if let data = cardsData.first(where: { $0.bounds.contains(drag.location) }) {
-                if selectedCardsIndices.last ?? -1 != data.index {
-                    selectedCardsIndices.append(data.index)
-                }
-            }
+        guard !locked else { return }
 
-            particleSystem.center.x = drag.location.x / UIScreen.main.bounds.width
-            particleSystem.center.y = drag.location.y / UIScreen.main.bounds.height
-            particleSystem.addParticle(at: drag.location)
+        if !wasDragging {
+            particleSystem.resetTrail()
         }
+
+        if let data = cardsData.first(where: { $0.bounds.contains(drag.location) }),
+           selectedCardsIndices.last ?? -1 != data.index {
+            selectedCardsIndices.append(data.index)
+        }
+
+        particleSystem.addParticle(at: drag.location)
     }
 
+    /// Completes the current drag gesture and dispatches setup or authentication.
+    ///
+    /// The method does not return a value. It mutates flow state and may invoke
+    /// a completion callback.
+    /// - Throws: This method does not throw. Credential errors are converted to
+    ///   user-facing state.
     public func afterDrag() {
         isDragging = false
-        if !selectedCardsIndices.isEmpty {
-            if debug {
-                print("[DEBUG] Drag ended, hash is: \(currentHash)")
-            }
-            switch mode {
-            case .authenticate:
-                authenticateHash()
-            case .set:
-                locked = true
-                if !valid {
-                    withAnimation {
-                        incorrectCount += 1
-                    }
-                    lastDragError = "Not long enough. Pattern must include at least \(minimumVertices ?? .max) vertices"
-                } else {
-                    if confirmationState == .awaitingConfirmation {
-                        if currentHash == firstPatternHash {
-                            confirmationState = .confirmed
-                            setupCompletion?(currentHash)
-                        } else {
-                            // Patterns don't match, show error
-                            incorrectCount += 1
-                            lastDragError = "Patterns do not match. Please try again."
-                        }
-                        selectedCardsIndices = []
-                        locked = false
-                    }
+        guard !selectedCardsIndices.isEmpty else { return }
+        particleSystem.resetTrail()
+
+        if debug {
+            print("[DEBUG] Drag ended with \(selectedCardsIndices.count) selected vertices.")
+        }
+
+        switch mode {
+        case .authenticate:
+            authenticateHash()
+        case .set:
+            locked = true
+            lastDragError = nil
+            guard valid else {
+                withAnimation {
+                    incorrectCount += 1
                 }
+                lastDragError = "Not long enough. Pattern must include at least \(minimumVertices ?? .max) vertices"
+                return
             }
+            handleSetPattern()
         }
     }
 
+    /// Authenticates the currently selected pattern.
+    ///
+    /// The method does not return a value. The configured authentication
+    /// completion is invoked with `true` or `false`.
+    /// - Throws: This method does not throw. Verification errors are converted
+    ///   to failed authentication state.
     public func authenticateHash() {
-        if currentHash == expectedHash {
+        let pattern = selectedCardsIndices
+        let success = authenticationSucceeds(for: pattern)
+
+        if success {
             incorrectHash = nil
             authCompletion?(true)
         } else {
-            incorrectHash = true
-            selectedCardsIndices = []
-            withAnimation(.easeInOut(duration: 0.3)) {
-                incorrectCount += 1
-            }
+            failAuthentication()
         }
     }
 
+    /// Replays a pattern by emitting particles along captured grid centers.
+    ///
+    /// - Parameter pattern: Ordered 3x3 grid vertex indices to replay.
+    /// This method does not return a value. Replay state and particles are
+    /// updated asynchronously on the main actor.
+    /// - Throws: This method does not throw.
     public func simulatePattern(_ pattern: [Int]) {
+        simulatePattern(
+            pattern,
+            initialDelayNanoseconds: 500_000_000,
+            pointDelayNanoseconds: 20_000_000
+        )
+    }
+
+    /// Replays a pattern with explicit timing for tests and preview harnesses.
+    ///
+    /// - Parameters:
+    ///   - pattern: Ordered 3x3 grid vertex indices to replay.
+    ///   - initialDelayNanoseconds: Delay before the first particle is emitted.
+    ///     No default.
+    ///   - pointDelayNanoseconds: Delay between emitted replay points. No
+    ///     default.
+    /// This method does not return a value. Replay state and particles are
+    /// updated asynchronously on the main actor.
+    /// - Throws: This method does not throw.
+    func simulatePattern(
+        _ pattern: [Int],
+        initialDelayNanoseconds: UInt64,
+        pointDelayNanoseconds: UInt64
+    ) {
         cancelSimulation()
         isSimulating = true
         simulationTask = Task { @MainActor in
-            defer { isSimulating = false }
-            try? await Task.sleep(nanoseconds: 500_000_000)
-            var lastCenter: CGPoint?
-            for index in pattern {
+            particleSystem.resetTrail()
+            defer {
+                particleSystem.resetTrail()
+                isSimulating = false
+            }
+            if initialDelayNanoseconds > 0 {
+                try? await Task.sleep(nanoseconds: initialDelayNanoseconds)
+            }
+            let replayPoints = simulationPoints(for: pattern)
+
+            for point in replayPoints {
                 if Task.isCancelled { return }
-                if index >= 0 && index < cardsData.count {
-                    let cardBounds = cardsData[index].bounds
-                    let cardCenter = CGPoint(x: cardBounds.midX, y: cardBounds.midY)
-                    particleSystem.center = UnitPoint(x: cardCenter.x / UIScreen.main.bounds.width,
-                                                      y: cardCenter.y / UIScreen.main.bounds.height)
-                    particleSystem.addParticle(at: cardCenter)
-
-                    if let lastCenter = lastCenter {
-                        // Generate particles between points
-                        let steps = 10
-                        for i in 1 ... steps {
-                            if Task.isCancelled { return }
-                            let t = CGFloat(i) / CGFloat(steps)
-                            let intermediatePoint = CGPoint(
-                                x: lastCenter.x + (cardCenter.x - lastCenter.x) * t,
-                                y: lastCenter.y + (cardCenter.y - lastCenter.y) * t
-                            )
-                            particleSystem.center = UnitPoint(
-                                x: intermediatePoint.x / UIScreen.main.bounds.width,
-                                y: intermediatePoint.y / UIScreen.main.bounds.height
-                            )
-                            particleSystem.addParticle(at: intermediatePoint)
-                            try? await Task.sleep(nanoseconds: 20_000_000)
-                        }
-                    }
-
-                    lastCenter = cardCenter
-                    try? await Task.sleep(nanoseconds: 75_000_000)
+                particleSystem.addParticle(at: point)
+                if pointDelayNanoseconds > 0 {
+                    try? await Task.sleep(nanoseconds: pointDelayNanoseconds)
                 }
             }
         }
     }
 
+    /// Builds the deterministic grid-local replay path for a gesture pattern.
+    ///
+    /// - Parameters:
+    ///   - pattern: Ordered 3x3 grid vertex indices to replay.
+    ///   - stepsBetweenCenters: Number of interpolated steps between two
+    ///     adjacent selected centers. Defaults to `10`.
+    /// - Returns: Grid-local points beginning at the first available center and
+    ///   ending at the final available center.
+    /// - Throws: This method does not throw.
+    func simulationPoints(for pattern: [Int], stepsBetweenCenters: Int = 10) -> [CGPoint] {
+        guard stepsBetweenCenters > 0 else {
+            return pattern.compactMap { center(for: $0) }
+        }
+
+        var points: [CGPoint] = []
+        var lastCenter: CGPoint?
+
+        for index in pattern {
+            guard let cardCenter = center(for: index) else { continue }
+
+            if let lastCenter {
+                for step in 1 ... stepsBetweenCenters {
+                    let t = CGFloat(step) / CGFloat(stepsBetweenCenters)
+                    points.append(CGPoint(
+                        x: lastCenter.x + (cardCenter.x - lastCenter.x) * t,
+                        y: lastCenter.y + (cardCenter.y - lastCenter.y) * t
+                    ))
+                }
+            } else {
+                points.append(cardCenter)
+            }
+
+            lastCenter = cardCenter
+        }
+
+        return points
+    }
+
+    /// Cancels an active replay animation.
+    ///
+    /// This method does not return a value. Replay state is reset immediately.
+    /// - Throws: This method does not throw.
     public func cancelSimulation() {
         simulationTask?.cancel()
         simulationTask = nil
         isSimulating = false
     }
 
-    private func handleSetPattern() {
-        if requireConfirmation ?? false {
-            switch confirmationState {
-            case .initial:
-                if repeatInput ?? true {
-                    simulatePattern(selectedCardsIndices)
-                }
-            case .awaitingConfirmation:
-                if currentHash == firstPatternHash {
-                    confirmationState = .confirmed
-                    setupCompletion?(currentHash)
-                } else {
-                    // Patterns don't match, show error
-                    incorrectCount += 1
-                    selectedCardsIndices = []
-                    locked = false
-                }
-            case .confirmed:
-                // This shouldn't happen, but reset if it does
-                reset()
-            }
-        } else {
-            // No confirmation required, complete setup immediately
-            if repeatInput ?? true {
-                simulatePattern(selectedCardsIndices)
-            }
-            setupCompletion?(currentHash)
-        }
-    }
-
+    /// Stores the first setup pattern and moves to confirmation input.
+    ///
+    /// This method does not return a value. If the current pattern is valid,
+    /// confirmation state is updated and the selection is cleared.
+    /// - Throws: This method does not throw.
     public func confirmPattern() {
         if valid {
             firstPatternHash = currentHash
             confirmationState = .awaitingConfirmation
             selectedCardsIndices = []
             locked = false
+            lastDragError = nil
         }
     }
 
+    /// Resets the current setup or authentication attempt.
+    ///
+    /// This method does not return a value. Selection, lock state,
+    /// confirmation state, replay, and validation messages are cleared.
+    /// - Throws: This method does not throw.
     public func reset() {
         cancelSimulation()
         selectedCardsIndices = []
@@ -229,20 +394,282 @@ public class GridAuthenticatorViewModel: ObservableObject {
         lastDragError = nil
     }
 
+    /// Finds the grid-space center point for a grid index.
+    ///
+    /// - Parameter index: A zero-based 3x3 grid index.
+    /// - Returns: The captured center point for `index`, or `nil` when geometry
+    ///   has not been reported.
+    /// - Throws: This method does not throw.
+    public func center(for index: Int) -> CGPoint? {
+        cardsData.first(where: { $0.index == index }).map {
+            CGPoint(x: $0.bounds.midX, y: $0.bounds.midY)
+        }
+    }
+
+    /// Processes a completed setup gesture.
+    ///
+    /// This method does not return a value. It advances confirmation state,
+    /// creates a credential, or records validation failure state.
+    /// - Throws: This method does not throw. Credential creation errors are
+    ///   converted to `lastDragError`.
+    private func handleSetPattern() {
+        let pattern = selectedCardsIndices
+
+        if requireConfirmation ?? false {
+            switch confirmationState {
+            case .initial:
+                if repeatInput ?? true {
+                    simulatePattern(pattern)
+                }
+            case .awaitingConfirmation:
+                if legacyHashArray(pattern) == firstPatternHash {
+                    confirmationState = .confirmed
+                    completeSetup(with: pattern)
+                } else {
+                    incorrectCount += 1
+                    lastDragError = "Patterns do not match. Please try again."
+                    selectedCardsIndices = []
+                    locked = false
+                }
+            case .confirmed:
+                reset()
+            }
+        } else {
+            if repeatInput ?? true {
+                simulatePattern(pattern)
+            }
+            completeSetup(with: pattern)
+        }
+    }
+
+    /// Completes setup by invoking the configured legacy or v1 setup callback.
+    ///
+    /// - Parameter pattern: The validated vertex sequence to store.
+    /// This method does not return a value. It invokes a setup callback and
+    /// clears the current gesture on success.
+    /// - Throws: This method does not throw. Credential creation errors are
+    ///   converted to `lastDragError`.
+    private func completeSetup(with pattern: [Int]) {
+        do {
+            if let credentialSetupCompletion {
+                let credential = try GestureCredentialHasher.createCredential(
+                    for: pattern,
+                    configuration: hashConfiguration
+                )
+                credentialSetupCompletion(credential)
+            } else {
+                setupCompletion?(legacyHashArray(pattern))
+            }
+            selectedCardsIndices = []
+            locked = false
+        } catch {
+            incorrectCount += 1
+            lastDragError = "Unable to create gesture credential."
+            selectedCardsIndices = []
+            locked = false
+        }
+    }
+
+    /// Verifies a vertex sequence against the configured expected credential material.
+    ///
+    /// - Parameter pattern: The selected vertex sequence to authenticate.
+    /// - Returns: `true` when `pattern` matches the configured v1 credential or
+    ///   legacy hash; otherwise, `false`.
+    /// - Throws: This method does not throw. Verification and migration errors
+    ///   are converted to `lastDragError`.
+    private func authenticationSucceeds(for pattern: [Int]) -> Bool {
+        if let expectedCredential {
+            do {
+                return try GestureCredentialHasher.verify(vertices: pattern, against: expectedCredential)
+            } catch {
+                lastDragError = "Unable to verify gesture credential."
+                return false
+            }
+        }
+
+        guard let expectedHash else { return false }
+        let success = GestureCredentialHasher.verifyLegacySHA256(
+            vertices: pattern,
+            expectedHash: expectedHash
+        )
+
+        if success, let legacyUpgradeCompletion {
+            do {
+                let credential = try GestureCredentialHasher.createCredential(
+                    for: pattern,
+                    configuration: hashConfiguration
+                )
+                legacyUpgradeCompletion(credential)
+            } catch {
+                lastDragError = "Gesture matched, but credential migration failed."
+            }
+        }
+
+        return success
+    }
+
+    /// Applies failed-authentication UI state.
+    ///
+    /// This method does not return a value. It clears the selection, increments
+    /// the shake counter, and invokes the authentication completion with
+    /// `false`.
+    /// - Throws: This method does not throw.
+    private func failAuthentication() {
+        incorrectHash = true
+        selectedCardsIndices = []
+        withAnimation(.easeInOut(duration: 0.3)) {
+            incorrectCount += 1
+        }
+        authCompletion?(false)
+    }
+
+    /// Defines the setup or authentication flow hosted by `GridAuthenticator`.
     public enum GridAuthenticatorOption {
-        case authenticate(expectedHash: String, color: Color = .blue, interactionMode: InteractionMode = .drag, debug: Bool = false, completion: (Bool) -> Void)
-        case set(minimumVertices: Int = 6, color: Color = .blue, interactionMode: InteractionMode = .drag, requireConfirmation: Bool = true, repeatInput: Bool = true, debug: Bool = false, completion: (String) -> Void)
+        /// Creates a deprecated v0 setup flow that returns a legacy SHA-256 hash.
+        ///
+        /// - Parameters:
+        ///   - minimumVertices: Minimum selected vertices required before setup
+        ///     succeeds. Defaults to `6`.
+        ///   - color: Primary grid and particle color. Defaults to `.blue`.
+        ///   - interactionMode: Input style for the grid. Defaults to `.drag`.
+        ///   - requireConfirmation: Whether the user must repeat the pattern
+        ///     before completion. Defaults to `true`.
+        ///   - repeatInput: Whether the package replays the pattern after setup
+        ///     input. Defaults to `true`.
+        ///   - debug: Whether to show developer diagnostics. Defaults to
+        ///     `false`.
+        ///   - completion: Callback receiving the legacy hexadecimal SHA-256
+        ///     hash.
+        @available(*, deprecated, message: "Use setCredential(...) for salted gesture credentials.")
+        case set(
+            minimumVertices: Int = 6,
+            color: Color = .blue,
+            interactionMode: InteractionMode = .drag,
+            requireConfirmation: Bool = true,
+            repeatInput: Bool = true,
+            debug: Bool = false,
+            completion: (String) -> Void
+        )
+
+        /// Creates a deprecated v0 authentication flow against a legacy hash.
+        ///
+        /// - Parameters:
+        ///   - expectedHash: The legacy hexadecimal SHA-256 hash fetched by the
+        ///     app.
+        ///   - color: Primary grid and particle color. Defaults to `.blue`.
+        ///   - interactionMode: Input style for the grid. Defaults to `.drag`.
+        ///   - debug: Whether to show developer diagnostics. Defaults to
+        ///     `false`.
+        ///   - completion: Callback receiving `true` for a match or `false` for
+        ///     a failed attempt.
+        @available(*, deprecated, message: "Use authenticateCredential(...) for salted gesture credentials.")
+        case authenticate(
+            expectedHash: String,
+            color: Color = .blue,
+            interactionMode: InteractionMode = .drag,
+            debug: Bool = false,
+            completion: (Bool) -> Void
+        )
+
+        /// Creates a v1 setup flow that returns a salted credential envelope.
+        ///
+        /// - Parameters:
+        ///   - minimumVertices: Minimum selected vertices required before setup
+        ///     succeeds. Defaults to `6`.
+        ///   - color: Primary grid and particle color. Defaults to `.blue`.
+        ///   - interactionMode: Input style for the grid. Defaults to `.drag`.
+        ///   - requireConfirmation: Whether the user must repeat the pattern
+        ///     before completion. Defaults to `true`.
+        ///   - repeatInput: Whether the package replays the pattern after setup
+        ///     input. Defaults to `true`.
+        ///   - debug: Whether to show developer diagnostics. Defaults to
+        ///     `false`.
+        ///   - configuration: Hashing configuration for the new credential.
+        ///     Defaults to ``GestureHashConfiguration/recommended``.
+        ///   - completion: Callback receiving the newly created v1 credential
+        ///     envelope.
+        case setCredential(
+            minimumVertices: Int = 6,
+            color: Color = .blue,
+            interactionMode: InteractionMode = .drag,
+            requireConfirmation: Bool = true,
+            repeatInput: Bool = true,
+            debug: Bool = false,
+            configuration: GestureHashConfiguration = .recommended,
+            completion: (GestureCredentialEnvelope) -> Void
+        )
+
+        /// Creates a v1 authentication flow against a credential envelope.
+        ///
+        /// - Parameters:
+        ///   - credential: The stored credential envelope fetched by the app.
+        ///   - color: Primary grid and particle color. Defaults to `.blue`.
+        ///   - interactionMode: Input style for the grid. Defaults to `.drag`.
+        ///   - debug: Whether to show developer diagnostics. Defaults to
+        ///     `false`.
+        ///   - completion: Callback receiving `true` for a match or `false` for
+        ///     a failed attempt.
+        case authenticateCredential(
+            credential: GestureCredentialEnvelope,
+            color: Color = .blue,
+            interactionMode: InteractionMode = .drag,
+            debug: Bool = false,
+            completion: (Bool) -> Void
+        )
+
+        /// Creates a legacy authentication flow that upgrades successful logins to v1.
+        ///
+        /// - Parameters:
+        ///   - expectedHash: The legacy hexadecimal SHA-256 hash fetched by the
+        ///     app.
+        ///   - color: Primary grid and particle color. Defaults to `.blue`.
+        ///   - interactionMode: Input style for the grid. Defaults to `.drag`.
+        ///   - debug: Whether to show developer diagnostics. Defaults to
+        ///     `false`.
+        ///   - configuration: Hashing configuration for the upgraded v1
+        ///     credential. Defaults to ``GestureHashConfiguration/recommended``.
+        ///   - onCredentialUpgrade: Callback receiving the new v1 credential
+        ///     envelope after legacy authentication succeeds.
+        ///   - completion: Callback receiving `true` for a legacy match or
+        ///     `false` for a failed attempt.
+        case authenticateAndUpgrade(
+            expectedHash: String,
+            color: Color = .blue,
+            interactionMode: InteractionMode = .drag,
+            debug: Bool = false,
+            configuration: GestureHashConfiguration = .recommended,
+            onCredentialUpgrade: (GestureCredentialEnvelope) -> Void,
+            completion: (Bool) -> Void
+        )
     }
 
+    /// The high-level authenticator flow type.
     public enum AuthType {
-        case authenticate, set
+        /// Authenticate an entered gesture against expected credential material.
+        case authenticate
+
+        /// Create new credential material from an entered gesture.
+        case set
     }
 
+    /// The supported grid interaction styles.
     public enum InteractionMode {
-        case tap, drag
+        /// Tap-based selection.
+        case tap
+
+        /// Drag-based selection. This is the current default.
+        case drag
     }
 
+    /// The setup confirmation state.
     public enum ConfirmationState {
-        case initial, awaitingConfirmation, confirmed
+        /// The user is entering the first setup pattern.
+        case initial
+
+        /// The user is entering the confirmation pattern.
+        case awaitingConfirmation
+
+        /// The setup pattern was confirmed.
+        case confirmed
     }
 }

--- a/Sources/PatternAuthentication/GridAuthenticatorViewModel.swift
+++ b/Sources/PatternAuthentication/GridAuthenticatorViewModel.swift
@@ -84,6 +84,9 @@ public class GridAuthenticatorViewModel: ObservableObject {
     @Published public var isSimulating: Bool = false
     private var simulationTask: Task<Void, Never>?
 
+    /// The in-flight credential derivation or verification task.
+    private var credentialTask: Task<Void, Never>?
+
     /// Whether the user currently has an active drag gesture.
     @Published public var isDragging: Bool = false
 
@@ -254,14 +257,13 @@ public class GridAuthenticatorViewModel: ObservableObject {
     ///   to failed authentication state.
     public func authenticateHash() {
         let pattern = selectedCardsIndices
-        let success = authenticationSucceeds(for: pattern)
 
-        if success {
-            incorrectHash = nil
-            authCompletion?(true)
-        } else {
-            failAuthentication()
+        if let expectedCredential {
+            authenticateCredential(pattern, credential: expectedCredential)
+            return
         }
+
+        authenticateLegacyHash(pattern)
     }
 
     /// Replays a pattern by emitting particles along captured grid centers.
@@ -387,6 +389,7 @@ public class GridAuthenticatorViewModel: ObservableObject {
     /// - Throws: This method does not throw.
     public func reset() {
         cancelSimulation()
+        cancelCredentialTask()
         selectedCardsIndices = []
         locked = false
         confirmationState = .initial
@@ -450,62 +453,193 @@ public class GridAuthenticatorViewModel: ObservableObject {
     /// - Throws: This method does not throw. Credential creation errors are
     ///   converted to `lastDragError`.
     private func completeSetup(with pattern: [Int]) {
-        do {
-            if let credentialSetupCompletion {
-                let credential = try GestureCredentialHasher.createCredential(
+        if credentialSetupCompletion != nil {
+            startCredentialSetupTask(for: pattern)
+            return
+        }
+
+        setupCompletion?(legacyHashArray(pattern))
+        finishSetup()
+    }
+
+    /// Starts credential setup work without blocking the main actor.
+    ///
+    /// - Parameter pattern: The validated vertex sequence to store.
+    /// This method does not return a value. It invokes the credential setup
+    /// callback on the main actor after derivation finishes.
+    /// - Throws: This method does not throw. Credential creation errors are
+    ///   converted to `lastDragError`.
+    private func startCredentialSetupTask(for pattern: [Int]) {
+        cancelCredentialTask()
+        let configuration = hashConfiguration
+
+        credentialTask = Task { @MainActor [weak self] in
+            do {
+                let credential = try await Self.createCredentialOffMainActor(
                     for: pattern,
-                    configuration: hashConfiguration
+                    configuration: configuration
                 )
-                credentialSetupCompletion(credential)
-            } else {
-                setupCompletion?(legacyHashArray(pattern))
+                guard let self, !Task.isCancelled else { return }
+                credentialSetupCompletion?(credential)
+                finishSetup()
+            } catch {
+                guard let self, !Task.isCancelled else { return }
+                incorrectCount += 1
+                lastDragError = "Unable to create gesture credential."
+                finishSetup()
             }
-            selectedCardsIndices = []
-            locked = false
-        } catch {
-            incorrectCount += 1
-            lastDragError = "Unable to create gesture credential."
-            selectedCardsIndices = []
-            locked = false
         }
     }
 
-    /// Verifies a vertex sequence against the configured expected credential material.
+    /// Verifies a v1 credential without blocking the main actor.
     ///
-    /// - Parameter pattern: The selected vertex sequence to authenticate.
-    /// - Returns: `true` when `pattern` matches the configured v1 credential or
-    ///   legacy hash; otherwise, `false`.
-    /// - Throws: This method does not throw. Verification and migration errors
-    ///   are converted to `lastDragError`.
-    private func authenticationSucceeds(for pattern: [Int]) -> Bool {
-        if let expectedCredential {
+    /// - Parameters:
+    ///   - pattern: The selected vertex sequence to authenticate.
+    ///   - credential: The stored credential envelope fetched by the app.
+    /// This method does not return a value. It invokes the authentication
+    /// callback on the main actor after verification finishes.
+    /// - Throws: This method does not throw. Verification errors are converted
+    ///   to failed authentication state.
+    private func authenticateCredential(_ pattern: [Int], credential: GestureCredentialEnvelope) {
+        cancelCredentialTask()
+
+        credentialTask = Task { @MainActor [weak self] in
             do {
-                return try GestureCredentialHasher.verify(vertices: pattern, against: expectedCredential)
+                let success = try await Self.verifyCredentialOffMainActor(
+                    vertices: pattern,
+                    credential: credential
+                )
+                guard let self, !Task.isCancelled else { return }
+                if success {
+                    incorrectHash = nil
+                    authCompletion?(true)
+                } else {
+                    failAuthentication()
+                }
             } catch {
+                guard let self, !Task.isCancelled else { return }
                 lastDragError = "Unable to verify gesture credential."
-                return false
+                failAuthentication()
             }
         }
+    }
 
-        guard let expectedHash else { return false }
+    /// Authenticates a legacy v0 hash and optionally upgrades it to a v1 credential.
+    ///
+    /// - Parameter pattern: The selected vertex sequence to authenticate.
+    /// This method does not return a value. Legacy hash comparison happens
+    /// synchronously; optional v1 upgrade derivation runs off the main actor.
+    /// - Throws: This method does not throw. Migration errors are converted to
+    ///   `lastDragError` while preserving successful authentication.
+    private func authenticateLegacyHash(_ pattern: [Int]) {
+        guard let expectedHash else {
+            failAuthentication()
+            return
+        }
         let success = GestureCredentialHasher.verifyLegacySHA256(
             vertices: pattern,
             expectedHash: expectedHash
         )
 
-        if success, let legacyUpgradeCompletion {
-            do {
-                let credential = try GestureCredentialHasher.createCredential(
-                    for: pattern,
-                    configuration: hashConfiguration
-                )
-                legacyUpgradeCompletion(credential)
-            } catch {
-                lastDragError = "Gesture matched, but credential migration failed."
-            }
+        guard success else {
+            failAuthentication()
+            return
         }
 
-        return success
+        guard legacyUpgradeCompletion != nil else {
+            incorrectHash = nil
+            authCompletion?(true)
+            return
+        }
+
+        startLegacyUpgradeAuthenticationTask(for: pattern)
+    }
+
+    /// Creates an upgraded v1 credential after a successful legacy match.
+    ///
+    /// - Parameter pattern: The legacy-authenticated vertex sequence to upgrade.
+    /// This method does not return a value. It invokes the upgrade callback
+    /// before reporting authentication success, matching the previous callback
+    /// order without blocking the main actor.
+    /// - Throws: This method does not throw. Migration errors are converted to
+    ///   `lastDragError` while preserving successful authentication.
+    private func startLegacyUpgradeAuthenticationTask(for pattern: [Int]) {
+        cancelCredentialTask()
+        let configuration = hashConfiguration
+
+        credentialTask = Task { @MainActor [weak self] in
+            do {
+                let credential = try await Self.createCredentialOffMainActor(
+                    for: pattern,
+                    configuration: configuration
+                )
+                guard let self, !Task.isCancelled else { return }
+                legacyUpgradeCompletion?(credential)
+            } catch {
+                guard let self, !Task.isCancelled else { return }
+                lastDragError = "Gesture matched, but credential migration failed."
+            }
+
+            guard let self, !Task.isCancelled else { return }
+            incorrectHash = nil
+            authCompletion?(true)
+        }
+    }
+
+    /// Clears setup state after a setup attempt completes.
+    ///
+    /// This method does not return a value. It clears the selected pattern and
+    /// unlocks input.
+    /// - Throws: This method does not throw.
+    private func finishSetup() {
+        selectedCardsIndices = []
+        locked = false
+    }
+
+    /// Cancels any in-flight credential derivation or verification task.
+    ///
+    /// This method does not return a value. Already-started key derivation may
+    /// finish in the background, but cancelled tasks do not update view state.
+    /// - Throws: This method does not throw.
+    private func cancelCredentialTask() {
+        credentialTask?.cancel()
+        credentialTask = nil
+    }
+
+    /// Creates a v1 credential on a background executor.
+    ///
+    /// - Parameters:
+    ///   - pattern: Ordered 3x3 grid vertex indices in the range `0...8`.
+    ///   - configuration: The hashing configuration to use.
+    /// - Returns: A new credential envelope with a fresh random salt.
+    /// - Throws: Any error thrown by `GestureCredentialHasher.createCredential`.
+    private nonisolated static func createCredentialOffMainActor(
+        for pattern: [Int],
+        configuration: GestureHashConfiguration
+    ) async throws -> GestureCredentialEnvelope {
+        try await Task.detached(priority: .userInitiated) {
+            try GestureCredentialHasher.createCredential(
+                for: pattern,
+                configuration: configuration
+            )
+        }.value
+    }
+
+    /// Verifies a v1 credential on a background executor.
+    ///
+    /// - Parameters:
+    ///   - vertices: Ordered 3x3 grid vertex indices in the range `0...8`.
+    ///   - credential: The stored credential envelope fetched by the app.
+    /// - Returns: `true` when `vertices` derive the stored credential hash;
+    ///   otherwise, `false`.
+    /// - Throws: Any error thrown by `GestureCredentialHasher.verify`.
+    private nonisolated static func verifyCredentialOffMainActor(
+        vertices: [Int],
+        credential: GestureCredentialEnvelope
+    ) async throws -> Bool {
+        try await Task.detached(priority: .userInitiated) {
+            try GestureCredentialHasher.verify(vertices: vertices, against: credential)
+        }.value
     }
 
     /// Applies failed-authentication UI state.

--- a/Sources/PatternAuthentication/PatternAuthentication.docc/PatternAuthentication.md
+++ b/Sources/PatternAuthentication/PatternAuthentication.docc/PatternAuthentication.md
@@ -1,0 +1,48 @@
+# PatternAuthentication
+
+Build a SwiftUI 3x3 gesture-pattern setup and authentication flow with salted v1 credentials.
+
+## Overview
+
+Pattern Authentication provides the client-side UI and credential helpers for gesture-pattern authentication. The package creates and verifies `GestureCredentialEnvelope` values, while your app remains responsible for fetching, storing, and protecting those credentials.
+
+Use `GridAuthenticator` with `setCredential` for new setup:
+
+```swift
+GridAuthenticator(.setCredential { credential in
+    Task {
+        try await saveCredential(credential.base64Representation)
+    }
+})
+```
+
+Use `authenticateCredential` after your app fetches a stored envelope:
+
+```swift
+GridAuthenticator(.authenticateCredential(credential: credential) { success in
+    if success {
+        openAuthenticatedArea()
+    }
+})
+```
+
+## Topics
+
+### SwiftUI
+
+- ``GridAuthenticator``
+- ``GridAuthenticatorViewModel``
+- ``GridAuthenticatorViewModel/GridAuthenticatorOption``
+
+### Credentials
+
+- ``GestureCredentialEnvelope``
+- ``GestureCredentialHasher``
+- ``GestureHashConfiguration``
+- ``GesturePattern``
+- ``GestureKDF``
+- ``GestureCredentialError``
+
+### Compatibility
+
+- ``hashArray(_:)``

--- a/Sources/PatternAuthentication/PatternAuthentication.swift
+++ b/Sources/PatternAuthentication/PatternAuthentication.swift
@@ -3,9 +3,18 @@
 
 import SwiftUI
 
+/// A SwiftUI 3x3 gesture grid for pattern setup and authentication.
+@MainActor
 public struct GridAuthenticator: View {
+    /// The main-actor view model that owns gesture flow state.
     @ObservedObject public var viewModel: GridAuthenticatorViewModel
 
+    /// Creates a grid authenticator view for setup or authentication.
+    ///
+    /// - Parameter gridAuthModel: The setup or authentication option used to
+    ///   configure the backing view model.
+    /// - Returns: A SwiftUI view that presents the gesture grid.
+    /// - Throws: This initializer does not throw.
     public init(_ gridAuthModel: GridAuthenticatorViewModel.GridAuthenticatorOption) {
         viewModel = GridAuthenticatorViewModel(gridAuthModel)
     }
@@ -15,57 +24,65 @@ public struct GridAuthenticator: View {
     public var body: some View {
         VStack {
             if viewModel.debug {
-                Text("[DEBUG] Current Pattern: \(viewModel.selectedCardsIndices)")
+                Text("[DEBUG] Selected Vertices: \(viewModel.selectedCardsIndices.count)")
                     .padding()
-                if let eh = viewModel.expectedHash {
-                    Text("[DEBUG] Expected Hash: \(eh)")
+                if viewModel.expectedCredential != nil {
+                    Text("[DEBUG] Credential Mode: v1 envelope")
                         .padding()
-                }
-                if !viewModel.selectedCardsIndices.isEmpty {
-                    Text("[DEBUG] Current Hash: \(viewModel.currentHash)")
+                } else if viewModel.expectedHash != nil {
+                    Text("[DEBUG] Credential Mode: legacy hash")
                         .padding()
                 }
             }
-            ZStack {
-                LazyVGrid(columns: columns) {
-                    ForEach(0 ..< 9, id: \.self) { index in
-                        GlowyCircle(index: index, viewModel: viewModel)
-                            .padding()
-                            .tag(index)
-                    }
+            LazyVGrid(columns: columns, spacing: 40) {
+                ForEach(0 ..< 9, id: \.self) { index in
+                    GlowyCircle(index: index, viewModel: viewModel)
+                        .padding()
+                        .tag(index)
                 }
-                .frame(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height)
-                .onPreferenceChange(CardPreferenceKey.self) { value in
-                    viewModel.cardsData = value
-                }
-                .coordinateSpace(name: "GridSpace")
+            }
+            .overlay {
                 TimelineView(.animation) { timeline in
-                    Canvas { context, size in
+                    Canvas { context, _ in
                         let timelineDate = timeline.date.timeIntervalSinceReferenceDate
                         viewModel.particleSystem.update(date: timelineDate)
+
                         context.blendMode = .plusLighter
                         context.addFilter(.colorMultiply(viewModel.viewColor))
-
                         for particle in viewModel.particleSystem.particles {
-                            let xPos = particle.x * size.width
-                            let yPos = particle.y * size.height
-                            context.opacity = 1 - (timelineDate - particle.creationDate)
-                            context.draw(viewModel.particleSystem.image, at: CGPoint(x: xPos, y: yPos))
+                            let age = timelineDate - particle.creationDate
+                            let opacity = max(0, 1 - age / viewModel.particleSystem.particleLifetime)
+                            let particleDiameter = viewModel.particleSystem.particleDiameter
+                            let particleRect = CGRect(
+                                x: particle.x - particleDiameter / 2,
+                                y: particle.y - particleDiameter / 2,
+                                width: particleDiameter,
+                                height: particleDiameter
+                            )
+                            context.opacity = opacity
+                            context.draw(
+                                viewModel.particleSystem.image,
+                                in: particleRect
+                            )
                         }
                     }
                 }
-                .gesture(
-                    DragGesture(minimumDistance: 0)
-                        .onChanged { drag in
-                            viewModel.duringDrag(drag: drag)
-                        }
-                        .onEnded { _ in
-                            viewModel.afterDrag()
-                        }
-                )
-                .ignoresSafeArea()
+                .allowsHitTesting(false)
             }
-            .frame(maxWidth: /*@START_MENU_TOKEN@*/ .infinity/*@END_MENU_TOKEN@*/, maxHeight: UIScreen.main.bounds.height * 0.4)
+            .onPreferenceChange(CardPreferenceKey.self) { value in
+                viewModel.cardsData = value
+            }
+            .coordinateSpace(name: "GridSpace")
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 0, coordinateSpace: .named("GridSpace"))
+                    .onChanged { drag in
+                        viewModel.duringDrag(drag: drag)
+                    }
+                    .onEnded { _ in
+                        viewModel.afterDrag()
+                    }
+            )
 
             VStack {
                 Text(viewModel.validityText)
@@ -117,21 +134,21 @@ public struct GridAuthenticator: View {
                     }
                 }
             }
-            .onChange(of: viewModel.isSimulating) { isSimulating in
-                if isSimulating {
-                    // Optionally, you can disable user interaction here
-                } else {
-                    // Re-enable user interaction if needed
-                }
-            }
         }
         .modifier(Shake(animatableData: CGFloat(viewModel.incorrectCount)))
     }
 }
 
+/// A single selectable circle in the 3x3 gesture grid.
+@MainActor
 public struct GlowyCircle: View {
+    /// The zero-based 3x3 grid index represented by this circle.
     public var index: Int
+
+    /// Whether the selection glow is currently visible.
     @State public var isBeingTouched: Bool = false
+
+    /// The view model that receives geometry and selection updates.
     @ObservedObject public var viewModel: GridAuthenticatorViewModel
 
     public var body: some View {
@@ -159,6 +176,11 @@ public struct GlowyCircle: View {
         }
     }
 
+    /// Temporarily highlights the circle after it is selected.
+    ///
+    /// The method does not return a value. It toggles ``isBeingTouched`` and
+    /// animates it back to `false`.
+    /// - Throws: This method does not throw.
     public func triggerGlow() {
         isBeingTouched = true
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
@@ -169,17 +191,53 @@ public struct GlowyCircle: View {
     }
 }
 
-public struct CardPreferenceData: Equatable {
+/// Geometry captured for one gesture grid circle.
+public struct CardPreferenceData: Equatable, Sendable {
+    /// The zero-based 3x3 grid index for the circle.
     public let index: Int
+
+    /// The circle bounds in the named grid coordinate space.
     public let bounds: CGRect
+
+    /// Creates captured geometry for a gesture grid circle.
+    ///
+    /// - Parameters:
+    ///   - index: The zero-based 3x3 grid index.
+    ///   - bounds: The circle bounds in the named grid coordinate space.
+    /// - Returns: A geometry record used by the view model for hit testing and
+    ///   path rendering.
+    /// - Throws: This initializer does not throw.
+    public init(index: Int, bounds: CGRect) {
+        self.index = index
+        self.bounds = bounds
+    }
 }
 
+/// Aggregates grid circle geometry emitted by SwiftUI preferences.
 public struct CardPreferenceKey: PreferenceKey {
+    /// The preference value type.
     public typealias Value = [CardPreferenceData]
 
-    public static var defaultValue: [CardPreferenceData] = []
+    /// The default preference value before any circles report geometry.
+    public static let defaultValue: [CardPreferenceData] = []
 
+    /// Appends newly reported circle geometry to the current preference value.
+    ///
+    /// - Parameters:
+    ///   - value: The accumulated preference value to mutate.
+    ///   - nextValue: A closure returning the next batch of geometry values.
+    /// The method does not return a value. It mutates `value` in place.
+    /// - Throws: This method does not throw.
     public static func reduce(value: inout [CardPreferenceData], nextValue: () -> [CardPreferenceData]) {
         value.append(contentsOf: nextValue())
     }
 }
+
+#if DEBUG
+struct GridAuthenticatorPreviews: PreviewProvider {
+    static var previews: some View {
+        GridAuthenticator(.setCredential(debug: true) { _ in })
+            .previewDisplayName("Credential Setup")
+    }
+}
+#endif

--- a/Sources/PatternAuthentication/PatternAuthentication.swift
+++ b/Sources/PatternAuthentication/PatternAuthentication.swift
@@ -6,8 +6,8 @@ import SwiftUI
 /// A SwiftUI 3x3 gesture grid for pattern setup and authentication.
 @MainActor
 public struct GridAuthenticator: View {
-    /// The main-actor view model that owns gesture flow state.
-    @ObservedObject public var viewModel: GridAuthenticatorViewModel
+    /// The main-actor state object that owns gesture flow state.
+    @StateObject public var viewModel: GridAuthenticatorViewModel
 
     /// Creates a grid authenticator view for setup or authentication.
     ///
@@ -16,7 +16,7 @@ public struct GridAuthenticator: View {
     /// - Returns: A SwiftUI view that presents the gesture grid.
     /// - Throws: This initializer does not throw.
     public init(_ gridAuthModel: GridAuthenticatorViewModel.GridAuthenticatorOption) {
-        viewModel = GridAuthenticatorViewModel(gridAuthModel)
+        _viewModel = StateObject(wrappedValue: GridAuthenticatorViewModel(gridAuthModel))
     }
 
     let columns = Array(repeating: GridItem(.fixed(60), spacing: 40), count: 3)

--- a/Sources/PatternAuthentication/PatternAuthentication.swift
+++ b/Sources/PatternAuthentication/PatternAuthentication.swift
@@ -146,7 +146,7 @@ public struct GlowyCircle: View {
     public var index: Int
 
     /// Whether the selection glow is currently visible.
-    @State public var isBeingTouched: Bool = false
+    @State private var isBeingTouched: Bool = false
 
     /// The view model that receives geometry and selection updates.
     @ObservedObject public var viewModel: GridAuthenticatorViewModel

--- a/Sources/PatternAuthentication/PatternAuthentication.swift
+++ b/Sources/PatternAuthentication/PatternAuthentication.swift
@@ -181,7 +181,7 @@ public struct GlowyCircle: View {
     /// The method does not return a value. It toggles ``isBeingTouched`` and
     /// animates it back to `false`.
     /// - Throws: This method does not throw.
-    public func triggerGlow() {
+    private func triggerGlow() {
         isBeingTouched = true
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
             withAnimation(.easeInOut(duration: 0.3)) {

--- a/Tests/PatternAuthenticationTests/AnimationSupportTests.swift
+++ b/Tests/PatternAuthenticationTests/AnimationSupportTests.swift
@@ -19,6 +19,19 @@ struct AnimationSupportTests {
         #expect(system.particles.isEmpty)
     }
 
+    @Test("Particle system expires multiple particles safely")
+    func particleSystemExpiresMultipleParticlesSafely() {
+        let system = ParticleSystem(emissionSpacing: 5)
+        system.addParticle(at: CGPoint(x: 0, y: 0))
+        system.addParticle(at: CGPoint(x: 20, y: 0))
+        #expect(system.particles.count == 5)
+
+        let futureDate = Date.now.timeIntervalSinceReferenceDate + 2
+        system.update(date: futureDate)
+
+        #expect(system.particles.isEmpty)
+    }
+
     @Test("Particle system interpolates fast movement")
     func particleSystemInterpolatesFastMovement() {
         let system = ParticleSystem(particleDiameter: 44, emissionSpacing: 5, particleLifetime: 1)

--- a/Tests/PatternAuthenticationTests/AnimationSupportTests.swift
+++ b/Tests/PatternAuthenticationTests/AnimationSupportTests.swift
@@ -1,0 +1,71 @@
+import CoreGraphics
+import SwiftUI
+import Testing
+@testable import PatternAuthentication
+
+@Suite("Animation Support")
+@MainActor
+struct AnimationSupportTests {
+    @Test("Particle system adds and expires particles")
+    func particleSystemLifecycle() {
+        let system = ParticleSystem()
+        system.addParticle(at: CGPoint(x: 10, y: 20))
+        #expect(system.particles.count == 1)
+        #expect(system.particles.first?.x == 10)
+        #expect(system.particles.first?.y == 20)
+
+        let futureDate = Date.now.timeIntervalSinceReferenceDate + 2
+        system.update(date: futureDate)
+        #expect(system.particles.isEmpty)
+    }
+
+    @Test("Particle system interpolates fast movement")
+    func particleSystemInterpolatesFastMovement() {
+        let system = ParticleSystem(particleDiameter: 44, emissionSpacing: 5, particleLifetime: 1)
+
+        system.addParticle(at: CGPoint(x: 0, y: 0))
+        system.addParticle(at: CGPoint(x: 20, y: 0))
+
+        let emittedXPositions = Set(system.particles.map { Int($0.x.rounded()) })
+        #expect(system.particles.count == 5)
+        #expect(emittedXPositions == [0, 5, 10, 15, 20])
+    }
+
+    @Test("Particle trail reset prevents cross-stroke interpolation")
+    func particleTrailResetPreventsCrossStrokeInterpolation() {
+        let system = ParticleSystem(emissionSpacing: 5)
+
+        system.addParticle(at: CGPoint(x: 0, y: 0))
+        system.resetTrail()
+        system.addParticle(at: CGPoint(x: 100, y: 0))
+
+        #expect(system.particles.count == 2)
+    }
+
+    @Test("Particle system clamps rendering configuration")
+    func particleSystemClampsRenderingConfiguration() {
+        let system = ParticleSystem(particleDiameter: -10, emissionSpacing: 0, particleLifetime: -1)
+
+        #expect(system.particleDiameter == 1)
+        #expect(system.emissionSpacing == 1)
+        #expect(system.particleLifetime == 0.1)
+    }
+
+    @Test("Shake effect creates a projection transform")
+    func shakeEffectProducesTransform() {
+        let shake = Shake(amount: 10, shakesPerUnit: 3, animatableData: 1)
+        _ = shake.effectValue(size: CGSize(width: 100, height: 100))
+    }
+
+    @Test("Preference key appends card data")
+    func preferenceKeyReducesValues() {
+        var value = CardPreferenceKey.defaultValue
+        CardPreferenceKey.reduce(value: &value) {
+            [CardPreferenceData(index: 1, bounds: CGRect(x: 0, y: 0, width: 20, height: 20))]
+        }
+
+        #expect(value == [
+            CardPreferenceData(index: 1, bounds: CGRect(x: 0, y: 0, width: 20, height: 20)),
+        ])
+    }
+}

--- a/Tests/PatternAuthenticationTests/GestureCredentialTests.swift
+++ b/Tests/PatternAuthenticationTests/GestureCredentialTests.swift
@@ -115,7 +115,10 @@ struct GestureCredentialTests {
 
         #expect(hashArray(pattern) == legacyHash)
         #expect(GestureCredentialHasher.verifyLegacySHA256(vertices: pattern, expectedHash: legacyHash))
+        #expect(GestureCredentialHasher.verifyLegacySHA256(vertices: pattern, expectedHash: legacyHash.uppercased()))
         #expect(!GestureCredentialHasher.verifyLegacySHA256(vertices: [0, 4, 8], expectedHash: legacyHash))
+        #expect(!GestureCredentialHasher.verifyLegacySHA256(vertices: pattern, expectedHash: String(repeating: "a", count: 1_000)))
+        #expect(!GestureCredentialHasher.verifyLegacySHA256(vertices: pattern, expectedHash: String(repeating: "z", count: 64)))
     }
 
     @Test("Legacy hashes can be migrated after a successful match")

--- a/Tests/PatternAuthenticationTests/GestureCredentialTests.swift
+++ b/Tests/PatternAuthenticationTests/GestureCredentialTests.swift
@@ -1,0 +1,263 @@
+import Foundation
+import Testing
+@testable import PatternAuthentication
+
+@Suite("Gesture Credential Core")
+struct GestureCredentialTests {
+    @Test("Canonical encoding is stable")
+    func canonicalEncodingIsStable() throws {
+        let pattern = try GesturePattern([0, 4, 8])
+        var expected = Data("PatternAuthentication.GesturePattern.v1".utf8)
+        expected.append(0)
+        expected.append(contentsOf: [0, 3, 0, 4, 8])
+
+        #expect(pattern.canonicalData == expected)
+    }
+
+    @Test("PBKDF2-HMAC-SHA256 matches known vector")
+    func pbkdf2SHA256KnownVector() throws {
+        let key = try GestureCredentialHasher.deriveKey(
+            password: Data("password".utf8),
+            salt: Data("salt".utf8),
+            kdf: .pbkdf2SHA256,
+            iterations: 1,
+            derivedKeyLength: 32
+        )
+
+        #expect(key.hexString == "120fb6cffcf8b32c43e7225256c4f837a86548c92ccc35480805987cb70be17b")
+    }
+
+    @Test("Credentials use unique salts")
+    func credentialsUseUniqueSalts() throws {
+        let configuration = GestureHashConfiguration(iterations: 1, saltLength: 16)
+        let first = try GestureCredentialHasher.createCredential(
+            for: [0, 1, 2, 5, 8, 7],
+            configuration: configuration
+        )
+        let second = try GestureCredentialHasher.createCredential(
+            for: [0, 1, 2, 5, 8, 7],
+            configuration: configuration
+        )
+
+        #expect(first.salt != second.salt)
+        #expect(first.hash != second.hash)
+    }
+
+    @Test("Credential verification succeeds and fails correctly")
+    func credentialVerification() throws {
+        let configuration = GestureHashConfiguration(iterations: 1, saltLength: 16)
+        let credential = try GestureCredentialHasher.createCredential(
+            for: [0, 1, 2, 5, 8, 7],
+            configuration: configuration
+        )
+
+        let success = try GestureCredentialHasher.verify(
+            vertices: [0, 1, 2, 5, 8, 7],
+            against: credential
+        )
+        let failure = try GestureCredentialHasher.verify(
+            vertices: [0, 1, 2, 5, 8, 6],
+            against: credential
+        )
+
+        #expect(success)
+        #expect(!failure)
+    }
+
+    @Test("Base64 and JSON round trips preserve credentials")
+    func storageRoundTrips() throws {
+        let configuration = GestureHashConfiguration(iterations: 1, saltLength: 16)
+        let credential = try GestureCredentialHasher.createCredential(
+            for: [0, 3, 6, 7, 8, 5],
+            configuration: configuration
+        )
+
+        let base64RoundTrip = try GestureCredentialEnvelope(
+            base64Representation: credential.base64Representation
+        )
+        let jsonRoundTrip = try GestureCredentialEnvelope.fromJSONData(
+            credential.jsonData()
+        )
+
+        #expect(base64RoundTrip == credential)
+        #expect(jsonRoundTrip == credential)
+    }
+
+    @Test("Invalid base64 storage fields throw typed errors")
+    func invalidBase64StorageThrows() {
+        #expect(throws: GestureCredentialError.self) {
+            try GestureCredentialEnvelope(base64Representation: .init(
+                salt: "not-base64",
+                hash: Data([1, 2, 3]).base64EncodedString(),
+                kdf: .pbkdf2SHA256,
+                iterations: 1,
+                hashVersion: 1,
+                derivedKeyLength: 32
+            ))
+        }
+
+        #expect(throws: GestureCredentialError.self) {
+            try GestureCredentialEnvelope(base64Representation: .init(
+                salt: Data([1, 2, 3]).base64EncodedString(),
+                hash: "not-base64",
+                kdf: .pbkdf2SHA256,
+                iterations: 1,
+                hashVersion: 1,
+                derivedKeyLength: 32
+            ))
+        }
+    }
+
+    @Test("Legacy hashes remain verifiable")
+    func legacyVerification() {
+        let pattern = [0, 4, 8, 5, 2, 1]
+        let legacyHash = legacyHashArray(pattern)
+
+        #expect(hashArray(pattern) == legacyHash)
+        #expect(GestureCredentialHasher.verifyLegacySHA256(vertices: pattern, expectedHash: legacyHash))
+        #expect(!GestureCredentialHasher.verifyLegacySHA256(vertices: [0, 4, 8], expectedHash: legacyHash))
+    }
+
+    @Test("Legacy hashes can be migrated after a successful match")
+    func legacyMigration() throws {
+        let pattern = [0, 4, 8, 5, 2, 1]
+        let legacyHash = legacyHashArray(pattern)
+        let configuration = GestureHashConfiguration(iterations: 1, saltLength: 16)
+
+        let credential = try #require(try GestureCredentialHasher.upgradeLegacyCredential(
+            vertices: pattern,
+            expectedHash: legacyHash,
+            configuration: configuration
+        ))
+
+        let verifies = try GestureCredentialHasher.verify(vertices: pattern, against: credential)
+        #expect(verifies)
+
+        let failedUpgrade = try GestureCredentialHasher.upgradeLegacyCredential(
+            vertices: [0, 4, 8],
+            expectedHash: legacyHash,
+            configuration: configuration
+        )
+        #expect(failedUpgrade == nil)
+    }
+
+    @Test("Constant-time comparison returns correct equality")
+    func constantTimeComparison() {
+        #expect(GestureCredentialHasher.constantTimeEquals(Data([1, 2, 3]), Data([1, 2, 3])))
+        #expect(!GestureCredentialHasher.constantTimeEquals(Data([1, 2, 3]), Data([1, 2, 4])))
+        #expect(!GestureCredentialHasher.constantTimeEquals(Data([1, 2, 3]), Data([1, 2, 3, 4])))
+    }
+
+    @Test("Invalid patterns are rejected")
+    func invalidPatternFails() {
+        #expect(throws: GestureCredentialError.self) {
+            try GesturePattern([0, 9])
+        }
+
+        #expect(throws: GestureCredentialError.self) {
+            try GesturePattern([])
+        }
+    }
+
+    @Test("Configuration validation rejects unusable values")
+    func invalidConfigurationFails() {
+        #expect(throws: GestureCredentialError.self) {
+            try GestureCredentialHasher.createCredential(
+                for: [0, 1, 2],
+                configuration: GestureHashConfiguration(iterations: 0)
+            )
+        }
+
+        #expect(throws: GestureCredentialError.self) {
+            try GestureCredentialHasher.createCredential(
+                for: [0, 1, 2],
+                configuration: GestureHashConfiguration(iterations: 1, saltLength: 15)
+            )
+        }
+
+        #expect(throws: GestureCredentialError.self) {
+            try GestureCredentialHasher.createCredential(
+                for: [0, 1, 2],
+                configuration: GestureHashConfiguration(
+                    iterations: 1,
+                    saltLength: 16,
+                    derivedKeyLength: 15
+                )
+            )
+        }
+
+        #expect(throws: GestureCredentialError.self) {
+            try GestureCredentialHasher.createCredential(
+                for: [0, 1, 2],
+                configuration: GestureHashConfiguration(
+                    iterations: 1,
+                    saltLength: 16,
+                    derivedKeyLength: 16,
+                    hashVersion: 0
+                )
+            )
+        }
+    }
+
+    @Test("Credential validation rejects malformed envelopes")
+    func malformedCredentialFails() {
+        #expect(throws: GestureCredentialError.self) {
+            try GestureCredentialHasher.verify(
+                vertices: [0, 1, 2],
+                against: GestureCredentialEnvelope(
+                    salt: Data(repeating: 1, count: 15),
+                    hash: Data(repeating: 2, count: 32),
+                    kdf: .pbkdf2SHA256,
+                    iterations: 1,
+                    hashVersion: 1,
+                    derivedKeyLength: 32
+                )
+            )
+        }
+
+        #expect(throws: GestureCredentialError.self) {
+            try GestureCredentialHasher.verify(
+                vertices: [0, 1, 2],
+                against: GestureCredentialEnvelope(
+                    salt: Data(repeating: 1, count: 16),
+                    hash: Data(repeating: 2, count: 31),
+                    kdf: .pbkdf2SHA256,
+                    iterations: 1,
+                    hashVersion: 1,
+                    derivedKeyLength: 32
+                )
+            )
+        }
+    }
+
+    @Test("Credential errors have readable descriptions")
+    func credentialErrorDescriptions() {
+        let errors: [GestureCredentialError] = [
+            .emptyPattern,
+            .invalidVertex(9),
+            .patternTooLong(70_000),
+            .invalidIterationCount(0),
+            .invalidSaltLength(1),
+            .invalidDerivedKeyLength(1),
+            .invalidHashVersion(0),
+            .secureRandomFailed(-1),
+            .unsupportedKDF(.pbkdf2SHA256),
+            .derivationFailed(-1),
+            .invalidBase64(field: "salt"),
+        ]
+
+        #expect(errors.allSatisfy { !$0.description.isEmpty })
+    }
+
+    @Test("Spark asset is available from the package bundle")
+    @MainActor
+    func sparkAssetLoads() {
+        #expect(PatternAuthenticationResourceProbe.sparkImageExists)
+    }
+}
+
+private extension Data {
+    var hexString: String {
+        map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Tests/PatternAuthenticationTests/GestureCredentialTests.swift
+++ b/Tests/PatternAuthenticationTests/GestureCredentialTests.swift
@@ -215,8 +215,8 @@ struct GestureCredentialTests {
             )
         }
 
-        #expect(throws: GestureCredentialError.self) {
-            try GestureCredentialHasher.verify(
+        do {
+            _ = try GestureCredentialHasher.verify(
                 vertices: [0, 1, 2],
                 against: GestureCredentialEnvelope(
                     salt: Data(repeating: 1, count: 16),
@@ -227,6 +227,11 @@ struct GestureCredentialTests {
                     derivedKeyLength: 32
                 )
             )
+            Issue.record("Expected hash length mismatch to throw.")
+        } catch let error as GestureCredentialError {
+            #expect(error == .hashLengthMismatch(expected: 32, actual: 31))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
         }
     }
 
@@ -239,6 +244,7 @@ struct GestureCredentialTests {
             .invalidIterationCount(0),
             .invalidSaltLength(1),
             .invalidDerivedKeyLength(1),
+            .hashLengthMismatch(expected: 32, actual: 31),
             .invalidHashVersion(0),
             .secureRandomFailed(-1),
             .unsupportedKDF(.pbkdf2SHA256),

--- a/Tests/PatternAuthenticationTests/GridAuthenticatorViewModelTests.swift
+++ b/Tests/PatternAuthenticationTests/GridAuthenticatorViewModelTests.swift
@@ -368,8 +368,9 @@ struct GridAuthenticatorViewModelTests {
 
     @Test("SwiftUI body smoke test")
     func swiftUIBodySmokeTest() {
-        let view = GridAuthenticator(.setCredential(repeatInput: false) { _ in })
-        _ = view.body
+        let host = UIHostingController(rootView: GridAuthenticator(.setCredential(repeatInput: false) { _ in }))
+        host.loadViewIfNeeded()
+        #expect(host.view != nil)
 
         let circle = GlowyCircle(
             index: 0,

--- a/Tests/PatternAuthenticationTests/GridAuthenticatorViewModelTests.swift
+++ b/Tests/PatternAuthenticationTests/GridAuthenticatorViewModelTests.swift
@@ -73,6 +73,7 @@ struct GridAuthenticatorViewModelTests {
 
         viewModel.confirmPattern()
         #expect(viewModel.confirmationState == .awaitingConfirmation)
+        #expect(viewModel.firstPatternHash != nil)
 
         viewModel.selectedCardsIndices = [0, 1, 2]
         viewModel.afterDrag()
@@ -80,6 +81,7 @@ struct GridAuthenticatorViewModelTests {
         #expect(try await waitForCondition { completedCredential != nil })
         let credential = try #require(completedCredential)
         #expect(viewModel.confirmationState == .confirmed)
+        #expect(viewModel.firstPatternHash == nil)
         #expect(try GestureCredentialHasher.verify(vertices: [0, 1, 2], against: credential))
     }
 

--- a/Tests/PatternAuthenticationTests/GridAuthenticatorViewModelTests.swift
+++ b/Tests/PatternAuthenticationTests/GridAuthenticatorViewModelTests.swift
@@ -1,0 +1,371 @@
+import CoreGraphics
+import Foundation
+import SwiftUI
+import Testing
+@testable import PatternAuthentication
+
+@Suite("Grid Authenticator View Model")
+@MainActor
+struct GridAuthenticatorViewModelTests {
+    @Test("Credential setup completes without confirmation")
+    func credentialSetupCompletesWithoutConfirmation() throws {
+        var completedCredential: GestureCredentialEnvelope?
+        let viewModel = GridAuthenticatorViewModel(.setCredential(
+            minimumVertices: 3,
+            requireConfirmation: false,
+            repeatInput: false,
+            configuration: .testFast
+        ) { credential in
+            completedCredential = credential
+        })
+
+        viewModel.selectedCardsIndices = [0, 1, 2]
+        viewModel.afterDrag()
+
+        let credential = try #require(completedCredential)
+        #expect(try GestureCredentialHasher.verify(vertices: [0, 1, 2], against: credential))
+        #expect(!viewModel.locked)
+    }
+
+    @Test("Credential setup reports creation errors")
+    func credentialSetupReportsCreationErrors() {
+        var didComplete = false
+        let invalidConfiguration = GestureHashConfiguration(
+            iterations: 1,
+            saltLength: 1
+        )
+        let viewModel = GridAuthenticatorViewModel(.setCredential(
+            minimumVertices: 3,
+            requireConfirmation: false,
+            repeatInput: false,
+            configuration: invalidConfiguration
+        ) { _ in
+            didComplete = true
+        })
+
+        viewModel.selectedCardsIndices = [0, 1, 2]
+        viewModel.afterDrag()
+
+        #expect(!didComplete)
+        #expect(viewModel.lastDragError == "Unable to create gesture credential.")
+        #expect(viewModel.incorrectCount == 1)
+        #expect(!viewModel.locked)
+    }
+
+    @Test("Credential setup requires matching confirmation when enabled")
+    func credentialSetupConfirmationFlow() throws {
+        var completedCredential: GestureCredentialEnvelope?
+        let viewModel = GridAuthenticatorViewModel(.setCredential(
+            minimumVertices: 3,
+            requireConfirmation: true,
+            repeatInput: false,
+            configuration: .testFast
+        ) { credential in
+            completedCredential = credential
+        })
+
+        viewModel.selectedCardsIndices = [0, 1, 2]
+        viewModel.afterDrag()
+        #expect(viewModel.locked)
+        #expect(completedCredential == nil)
+
+        viewModel.confirmPattern()
+        #expect(viewModel.confirmationState == .awaitingConfirmation)
+
+        viewModel.selectedCardsIndices = [0, 1, 2]
+        viewModel.afterDrag()
+
+        let credential = try #require(completedCredential)
+        #expect(viewModel.confirmationState == .confirmed)
+        #expect(try GestureCredentialHasher.verify(vertices: [0, 1, 2], against: credential))
+    }
+
+    @Test("Mismatched confirmation fails and unlocks input")
+    func mismatchedConfirmationFails() {
+        var completionCount = 0
+        let viewModel = GridAuthenticatorViewModel(.setCredential(
+            minimumVertices: 3,
+            requireConfirmation: true,
+            repeatInput: false,
+            configuration: .testFast
+        ) { _ in
+            completionCount += 1
+        })
+
+        viewModel.selectedCardsIndices = [0, 1, 2]
+        viewModel.afterDrag()
+        viewModel.confirmPattern()
+        viewModel.selectedCardsIndices = [0, 1, 3]
+        viewModel.afterDrag()
+
+        #expect(completionCount == 0)
+        #expect(viewModel.lastDragError == "Patterns do not match. Please try again.")
+        #expect(!viewModel.locked)
+        #expect(viewModel.incorrectCount == 1)
+    }
+
+    @Test("Too-short setup pattern is rejected")
+    func tooShortPatternFails() {
+        var completed = false
+        let viewModel = GridAuthenticatorViewModel(.setCredential(
+            minimumVertices: 4,
+            requireConfirmation: false,
+            repeatInput: false,
+            configuration: .testFast
+        ) { _ in
+            completed = true
+        })
+
+        viewModel.selectedCardsIndices = [0, 1, 2]
+        viewModel.afterDrag()
+
+        #expect(!completed)
+        #expect(viewModel.locked)
+        #expect(viewModel.lastDragError == "Not long enough. Pattern must include at least 4 vertices")
+        #expect(viewModel.incorrectCount == 1)
+    }
+
+    @Test("Credential authentication reports success and failure")
+    func credentialAuthenticationReportsResult() throws {
+        let credential = try GestureCredentialHasher.createCredential(
+            for: [0, 1, 2, 5],
+            configuration: .testFast
+        )
+        var results: [Bool] = []
+        let viewModel = GridAuthenticatorViewModel(.authenticateCredential(
+            credential: credential
+        ) { success in
+            results.append(success)
+        })
+
+        viewModel.selectedCardsIndices = [0, 1, 2, 5]
+        viewModel.afterDrag()
+        viewModel.selectedCardsIndices = [0, 1, 2, 6]
+        viewModel.afterDrag()
+
+        #expect(results == [true, false])
+        #expect(viewModel.incorrectCount == 1)
+    }
+
+    @Test("Legacy authentication reports success and failure")
+    func legacyAuthenticationReportsResult() {
+        let pattern = [0, 1, 2, 5]
+        let expectedHash = legacyHashArray(pattern)
+        var results: [Bool] = []
+        let viewModel = GridAuthenticatorViewModel(.authenticate(expectedHash: expectedHash) { success in
+            results.append(success)
+        })
+
+        viewModel.selectedCardsIndices = pattern
+        viewModel.afterDrag()
+        viewModel.selectedCardsIndices = [0, 1, 2, 6]
+        viewModel.afterDrag()
+
+        #expect(results == [true, false])
+        #expect(viewModel.incorrectCount == 1)
+    }
+
+    @Test("Legacy setup returns the original hash")
+    func legacySetupReturnsOriginalHash() {
+        var completedHash: String?
+        let pattern = [0, 1, 2]
+        let viewModel = GridAuthenticatorViewModel(.set(
+            minimumVertices: 3,
+            requireConfirmation: false,
+            repeatInput: false
+        ) { hash in
+            completedHash = hash
+        })
+
+        viewModel.selectedCardsIndices = pattern
+        viewModel.afterDrag()
+
+        #expect(completedHash == legacyHashArray(pattern))
+    }
+
+    @Test("Legacy auth can emit an upgraded credential")
+    func legacyAuthUpgradeCallback() throws {
+        let pattern = [0, 4, 8, 5]
+        let legacyHash = legacyHashArray(pattern)
+        var upgradedCredential: GestureCredentialEnvelope?
+        var authResults: [Bool] = []
+        let viewModel = GridAuthenticatorViewModel(.authenticateAndUpgrade(
+            expectedHash: legacyHash,
+            configuration: .testFast,
+            onCredentialUpgrade: { credential in
+                upgradedCredential = credential
+            },
+            completion: { success in
+                authResults.append(success)
+            }
+        ))
+
+        viewModel.selectedCardsIndices = pattern
+        viewModel.afterDrag()
+
+        let credential = try #require(upgradedCredential)
+        #expect(authResults == [true])
+        #expect(try GestureCredentialHasher.verify(vertices: pattern, against: credential))
+    }
+
+    @Test("Credential authentication reports malformed envelopes")
+    func credentialAuthenticationReportsMalformedEnvelope() {
+        let malformedCredential = GestureCredentialEnvelope(
+            salt: Data([1]),
+            hash: Data(repeating: 2, count: 32),
+            kdf: .pbkdf2SHA256,
+            iterations: 1,
+            hashVersion: 1,
+            derivedKeyLength: 32
+        )
+        var results: [Bool] = []
+        let viewModel = GridAuthenticatorViewModel(.authenticateCredential(
+            credential: malformedCredential
+        ) { success in
+            results.append(success)
+        })
+
+        viewModel.selectedCardsIndices = [0, 1, 2]
+        viewModel.afterDrag()
+
+        #expect(results == [false])
+        #expect(viewModel.lastDragError == "Unable to verify gesture credential.")
+    }
+
+    @Test("Authentication fails when no expected material is configured")
+    func authenticationFailsWithoutExpectedMaterial() {
+        var results: [Bool] = []
+        let viewModel = GridAuthenticatorViewModel(.authenticate(expectedHash: "unused") { success in
+            results.append(success)
+        })
+        viewModel.expectedHash = nil
+        viewModel.selectedCardsIndices = [0, 1, 2]
+
+        viewModel.authenticateHash()
+
+        #expect(results == [false])
+        #expect(viewModel.incorrectHash == true)
+    }
+
+    @Test("Selected card centers follow preference data")
+    func selectedCardCentersFollowPreferenceData() {
+        let viewModel = GridAuthenticatorViewModel(.setCredential(repeatInput: false) { _ in })
+        viewModel.cardsData = [
+            CardPreferenceData(index: 0, bounds: CGRect(x: 0, y: 0, width: 10, height: 10)),
+            CardPreferenceData(index: 4, bounds: CGRect(x: 40, y: 40, width: 10, height: 10)),
+            CardPreferenceData(index: 8, bounds: CGRect(x: 80, y: 80, width: 10, height: 10)),
+        ]
+        viewModel.selectedCardsIndices = [0, 4, 8]
+
+        #expect(viewModel.selectedCardCenters == [
+            CGPoint(x: 5, y: 5),
+            CGPoint(x: 45, y: 45),
+            CGPoint(x: 85, y: 85),
+        ])
+        #expect(viewModel.mostRecentSelection == 8)
+    }
+
+    @Test("Validity text hides while dragging")
+    func validityTextHidesWhileDragging() {
+        let viewModel = GridAuthenticatorViewModel(.setCredential(repeatInput: false) { _ in })
+        viewModel.lastDragError = "Visible"
+        #expect(viewModel.validityText == "Visible")
+
+        viewModel.isDragging = true
+        #expect(viewModel.validityText == "")
+    }
+
+    @Test("Nil minimum vertices requires an impossible length")
+    func nilMinimumVerticesRequiresImpossibleLength() {
+        let viewModel = GridAuthenticatorViewModel(.setCredential(repeatInput: false) { _ in })
+        viewModel.minimumVertices = nil
+        viewModel.selectedCardsIndices = [0, 1, 2, 3, 4, 5, 6, 7, 8]
+
+        #expect(!viewModel.valid)
+    }
+
+    @Test("Simulation path follows configured centers")
+    func simulationPathFollowsConfiguredCenters() {
+        let viewModel = GridAuthenticatorViewModel(.setCredential(repeatInput: true) { _ in })
+        viewModel.cardsData = [
+            CardPreferenceData(index: 0, bounds: CGRect(x: 0, y: 0, width: 10, height: 10)),
+            CardPreferenceData(index: 1, bounds: CGRect(x: 40, y: 0, width: 10, height: 10)),
+        ]
+
+        let points = viewModel.simulationPoints(for: [0, 1], stepsBetweenCenters: 4)
+
+        #expect(points.count == 5)
+        #expect(points.first == CGPoint(x: 5, y: 5))
+        #expect(points.last == CGPoint(x: 45, y: 5))
+        #expect(points.contains(CGPoint(x: 25, y: 5)))
+    }
+
+    @Test("Simulation path supports zero interpolation steps")
+    func simulationPathSupportsZeroInterpolationSteps() {
+        let viewModel = GridAuthenticatorViewModel(.setCredential(repeatInput: true) { _ in })
+        viewModel.cardsData = [
+            CardPreferenceData(index: 0, bounds: CGRect(x: 0, y: 0, width: 10, height: 10)),
+            CardPreferenceData(index: 1, bounds: CGRect(x: 40, y: 0, width: 10, height: 10)),
+        ]
+
+        let points = viewModel.simulationPoints(for: [0, 1], stepsBetweenCenters: 0)
+
+        #expect(points == [
+            CGPoint(x: 5, y: 5),
+            CGPoint(x: 45, y: 5),
+        ])
+    }
+
+    @Test("Simulation emits particles with injected timing")
+    func simulationEmitsParticlesWithInjectedTiming() async throws {
+        let viewModel = GridAuthenticatorViewModel(.setCredential(repeatInput: true) { _ in })
+        viewModel.cardsData = [
+            CardPreferenceData(index: 0, bounds: CGRect(x: 0, y: 0, width: 10, height: 10)),
+            CardPreferenceData(index: 1, bounds: CGRect(x: 40, y: 0, width: 10, height: 10)),
+        ]
+
+        viewModel.simulatePattern(
+            [0, 1],
+            initialDelayNanoseconds: 0,
+            pointDelayNanoseconds: 0
+        )
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        #expect(!viewModel.isSimulating)
+        #expect(!viewModel.particleSystem.particles.isEmpty)
+    }
+
+    @Test("Reset clears setup state")
+    func resetClearsState() {
+        let viewModel = GridAuthenticatorViewModel(.setCredential(repeatInput: false) { _ in })
+        viewModel.selectedCardsIndices = [0, 1, 2]
+        viewModel.locked = true
+        viewModel.firstPatternHash = "hash"
+        viewModel.lastDragError = "error"
+        viewModel.confirmationState = .awaitingConfirmation
+
+        viewModel.reset()
+
+        #expect(viewModel.selectedCardsIndices.isEmpty)
+        #expect(!viewModel.locked)
+        #expect(viewModel.firstPatternHash == nil)
+        #expect(viewModel.lastDragError == nil)
+        #expect(viewModel.confirmationState == .initial)
+    }
+
+    @Test("SwiftUI body smoke test")
+    func swiftUIBodySmokeTest() {
+        let view = GridAuthenticator(.setCredential(repeatInput: false) { _ in })
+        _ = view.body
+
+        let circle = GlowyCircle(
+            index: 0,
+            viewModel: GridAuthenticatorViewModel(.setCredential(repeatInput: false) { _ in })
+        )
+        _ = circle.body
+    }
+}
+
+private extension GestureHashConfiguration {
+    static let testFast = GestureHashConfiguration(iterations: 1, saltLength: 16)
+}

--- a/Tests/PatternAuthenticationTests/GridAuthenticatorViewModelTests.swift
+++ b/Tests/PatternAuthenticationTests/GridAuthenticatorViewModelTests.swift
@@ -8,7 +8,7 @@ import Testing
 @MainActor
 struct GridAuthenticatorViewModelTests {
     @Test("Credential setup completes without confirmation")
-    func credentialSetupCompletesWithoutConfirmation() throws {
+    func credentialSetupCompletesWithoutConfirmation() async throws {
         var completedCredential: GestureCredentialEnvelope?
         let viewModel = GridAuthenticatorViewModel(.setCredential(
             minimumVertices: 3,
@@ -22,13 +22,14 @@ struct GridAuthenticatorViewModelTests {
         viewModel.selectedCardsIndices = [0, 1, 2]
         viewModel.afterDrag()
 
+        #expect(try await waitForCondition { completedCredential != nil })
         let credential = try #require(completedCredential)
         #expect(try GestureCredentialHasher.verify(vertices: [0, 1, 2], against: credential))
         #expect(!viewModel.locked)
     }
 
     @Test("Credential setup reports creation errors")
-    func credentialSetupReportsCreationErrors() {
+    func credentialSetupReportsCreationErrors() async throws {
         var didComplete = false
         let invalidConfiguration = GestureHashConfiguration(
             iterations: 1,
@@ -46,6 +47,7 @@ struct GridAuthenticatorViewModelTests {
         viewModel.selectedCardsIndices = [0, 1, 2]
         viewModel.afterDrag()
 
+        #expect(try await waitForCondition { viewModel.lastDragError != nil || didComplete })
         #expect(!didComplete)
         #expect(viewModel.lastDragError == "Unable to create gesture credential.")
         #expect(viewModel.incorrectCount == 1)
@@ -53,7 +55,7 @@ struct GridAuthenticatorViewModelTests {
     }
 
     @Test("Credential setup requires matching confirmation when enabled")
-    func credentialSetupConfirmationFlow() throws {
+    func credentialSetupConfirmationFlow() async throws {
         var completedCredential: GestureCredentialEnvelope?
         let viewModel = GridAuthenticatorViewModel(.setCredential(
             minimumVertices: 3,
@@ -75,6 +77,7 @@ struct GridAuthenticatorViewModelTests {
         viewModel.selectedCardsIndices = [0, 1, 2]
         viewModel.afterDrag()
 
+        #expect(try await waitForCondition { completedCredential != nil })
         let credential = try #require(completedCredential)
         #expect(viewModel.confirmationState == .confirmed)
         #expect(try GestureCredentialHasher.verify(vertices: [0, 1, 2], against: credential))
@@ -126,7 +129,7 @@ struct GridAuthenticatorViewModelTests {
     }
 
     @Test("Credential authentication reports success and failure")
-    func credentialAuthenticationReportsResult() throws {
+    func credentialAuthenticationReportsResult() async throws {
         let credential = try GestureCredentialHasher.createCredential(
             for: [0, 1, 2, 5],
             configuration: .testFast
@@ -140,9 +143,12 @@ struct GridAuthenticatorViewModelTests {
 
         viewModel.selectedCardsIndices = [0, 1, 2, 5]
         viewModel.afterDrag()
+        #expect(try await waitForCondition { results.count == 1 })
+
         viewModel.selectedCardsIndices = [0, 1, 2, 6]
         viewModel.afterDrag()
 
+        #expect(try await waitForCondition { results.count == 2 })
         #expect(results == [true, false])
         #expect(viewModel.incorrectCount == 1)
     }
@@ -184,7 +190,7 @@ struct GridAuthenticatorViewModelTests {
     }
 
     @Test("Legacy auth can emit an upgraded credential")
-    func legacyAuthUpgradeCallback() throws {
+    func legacyAuthUpgradeCallback() async throws {
         let pattern = [0, 4, 8, 5]
         let legacyHash = legacyHashArray(pattern)
         var upgradedCredential: GestureCredentialEnvelope?
@@ -203,13 +209,14 @@ struct GridAuthenticatorViewModelTests {
         viewModel.selectedCardsIndices = pattern
         viewModel.afterDrag()
 
+        #expect(try await waitForCondition { upgradedCredential != nil && authResults == [true] })
         let credential = try #require(upgradedCredential)
         #expect(authResults == [true])
         #expect(try GestureCredentialHasher.verify(vertices: pattern, against: credential))
     }
 
     @Test("Credential authentication reports malformed envelopes")
-    func credentialAuthenticationReportsMalformedEnvelope() {
+    func credentialAuthenticationReportsMalformedEnvelope() async throws {
         let malformedCredential = GestureCredentialEnvelope(
             salt: Data([1]),
             hash: Data(repeating: 2, count: 32),
@@ -228,6 +235,7 @@ struct GridAuthenticatorViewModelTests {
         viewModel.selectedCardsIndices = [0, 1, 2]
         viewModel.afterDrag()
 
+        #expect(try await waitForCondition { results.count == 1 })
         #expect(results == [false])
         #expect(viewModel.lastDragError == "Unable to verify gesture credential.")
     }
@@ -371,4 +379,23 @@ struct GridAuthenticatorViewModelTests {
 
 private extension GestureHashConfiguration {
     static let testFast = GestureHashConfiguration(iterations: 1, saltLength: 16)
+}
+
+@MainActor
+private func waitForCondition(
+    timeoutNanoseconds: UInt64 = 500_000_000,
+    pollIntervalNanoseconds: UInt64 = 1_000_000,
+    _ condition: @MainActor () -> Bool
+) async throws -> Bool {
+    let interval = max(pollIntervalNanoseconds, 1)
+    let attempts = max(1, Int(timeoutNanoseconds / interval))
+
+    for _ in 0 ..< attempts {
+        if condition() {
+            return true
+        }
+        try await Task.sleep(nanoseconds: interval)
+    }
+
+    return condition()
 }

--- a/Tests/PatternAuthenticationTests/GridAuthenticatorViewModelTests.swift
+++ b/Tests/PatternAuthenticationTests/GridAuthenticatorViewModelTests.swift
@@ -329,7 +329,10 @@ struct GridAuthenticatorViewModelTests {
             initialDelayNanoseconds: 0,
             pointDelayNanoseconds: 0
         )
-        try await Task.sleep(nanoseconds: 50_000_000)
+        for _ in 0 ..< 100 {
+            if !viewModel.isSimulating { break }
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
 
         #expect(!viewModel.isSimulating)
         #expect(!viewModel.particleSystem.particles.isEmpty)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 90%
+        threshold: 1%
+    patch:
+      default:
+        target: 90%
+
+ignore:
+  - "Sources/PatternAuthentication/PatternAuthentication.swift"
+  - "Tests/**"


### PR DESCRIPTION
The security credential upgrade release keeps the original 1.x gesture UI APIs available for existing apps and adds the v1 credential-envelope flow for production use.

### Added

- Added the v1 `GestureCredentialEnvelope` API for storing gesture credentials as a structured envelope rather than a single legacy hash string.
- Added `GesturePattern` to canonicalize selected grid indices before hashing, including a package-specific domain separator so the encoded gesture carries package and version context.
- Added `GestureHashConfiguration` for KDF parameters, with `.recommended` using PBKDF2-HMAC-SHA256, 600,000 iterations, a 32-byte salt, and a 32-byte derived key.
- Added `GestureKDF` so stored credentials can record the derivation algorithm used to create them.
- Added `GestureCredentialError` for typed failures around salt generation, hashing, unsupported credential versions, malformed base64, malformed JSON, and invalid KDF metadata.
- Added cryptographically secure random salt generation through Security framework APIs.
- Added constant-time comparison for derived hash verification.
- Added `Codable`, JSON, and base64 helpers for backend-friendly storage in document databases and APIs.
- Added `GridAuthenticator(.setCredential(...))` for new credential setup.
- Added `GridAuthenticator(.authenticateCredential(...))` for authenticating against a fetched v1 credential.
- Added `GridAuthenticator(.authenticateAndUpgrade(...))` for verifying a legacy v0 hash and returning a v1 credential envelope after a successful match.
- Added Swift 6 language mode in `Package.swift`.
- Added `Sendable` conformance for credential model types that can safely cross concurrency boundaries.
- Added main-actor isolation for UI-owned state.
- Added package tests for canonical gesture encoding, PBKDF2-HMAC-SHA256 known vectors, salt uniqueness, v1 credential verification, Codable round trips, base64 round trips, legacy verification, legacy-to-v1 migration, particle resource loading, and replay path behavior.
- Added GitHub Actions CI for Swift 6 builds, tests, coverage extraction, and a 90% package-logic coverage gate.
- Added Codecov configuration, LCOV conversion for Swift/Xcode coverage upload, and README badges for CI and coverage.
- Added a DocC catalog for package documentation.
- Added public API DocC comments for the non-view public types and methods.
- Added `Docs/MigrationGuide.md` for legacy SHA-256 migration.
- Added `SECURITY.md` with storage, lockout, session, and vulnerability-reporting guidance.

### Changed

- Reworked the README into a production integration guide with quickstart setup/authentication examples, backend responsibilities, Firestore-style storage guidance, security model notes, configuration defaults, troubleshooting, and versioning.
- Updated the package security model from unsalted SHA-256-only storage to a salted credential envelope while preserving source compatibility for existing 1.x clients.
- Updated setup and authentication examples to show app-owned backend fetch/save behavior.
- Updated particle rendering so the particle canvas, drag hit testing, and circle geometry all use the same grid-local coordinate space.
- Updated particle trails to interpolate fast drag movement and render at a fingertip-like thickness, reducing dotted gaps during quick swipes.
- Preserved the original particle-only visual style rather than switching to a deterministic path overlay.
- Updated SwiftUI layout so the grid itself defines the interactive drawing surface, avoiding full-screen coordinate drift in package consumers.
- Updated debug behavior so raw gesture hashes are no longer printed.
- Updated setup without confirmation so it completes after the first valid gesture while still honoring the default `repeatInput: true` replay.
- Updated failed authentication behavior so the completion handler is called with `false`.
- Updated the mutable static preference default to be Swift 6 concurrency friendly.

### Deprecated

- Deprecated `hashArray(_:)`. Use `GestureCredentialHasher.createCredential(for:configuration:)` or the new `GridAuthenticator(.setCredential(...))` flow instead.
- Deprecated `GridAuthenticator(.set(... completion: (String) -> Void))`. Use `GridAuthenticator(.setCredential(...))` for new setup flows.
- Deprecated `GridAuthenticator(.authenticate(expectedHash: ...))`. Use `GridAuthenticator(.authenticateCredential(...))` once a v1 envelope is stored.

### Fixed

- Fixed particle trails that could appear vertically offset from the selected circles in SwiftPM consumers.
- Fixed particle trails that could look like a dotted line during fast finger movement.
- Fixed replay cleanup so a previous path does not bleed into the next setup or authentication attempt.
- Fixed SwiftPM resource loading coverage for the `spark` asset bundle.
- Fixed failed authentication callbacks so integrators can reliably update UI after an incorrect pattern.

### Security

- New v1 credentials use a fresh per-credential salt and PBKDF2-HMAC-SHA256 rather than a raw unsalted gesture hash.
- Verification derives a candidate hash with the stored credential parameters and compares it in constant time.
- Credential metadata records KDF, iteration count, hash version, and derived key length so future migrations have enough context.
- Legacy SHA-256 APIs remain only for compatibility and migration. New production integrations should use v1 credentials.
- Apps remain responsible for backend storage, authorization, sessions, lockouts, attempt limits, audit logging, recovery, and deciding what a successful gesture unlocks.

### Backwards Compatibility

- This release adds APIs in 1.x.
- Existing calls to `GridAuthenticator(.set(... completion: (String) -> Void))`, `GridAuthenticator(.authenticate(expectedHash: ...))`, and `hashArray(_:)` should continue to compile with deprecation warnings.
- Existing stored legacy hashes can still be verified.
- Existing production apps can migrate one user at a time with `authenticateAndUpgrade` after a successful legacy match.
- `repeatInput` remains `true` by default.
- Apps that exhaustively switch over package enums may need to recompile and handle newer cases.
- Apps that depended on raw debug hash output should remove that dependency.

### Migration Notes

- For new users, store `GestureCredentialEnvelope.Base64Representation` fields in your app-owned backend or local secure storage.
- For existing users, keep the legacy hash until `authenticateAndUpgrade` succeeds and your app has saved the returned v1 credential.
- Do not delete a legacy hash if saving the new envelope fails.
- Store all v1 fields together: `salt`, `hash`, `kdf`, `iterations`, `hashVersion`, and `derivedKeyLength`.
- Treat the credential record as sensitive authenticator material.

### Testing

- Verified Swift 6 package builds for iOS.
- Added a focused package test suite covering credential creation, verification, migration, encoding, resources, and particle behavior.
- Added CI coverage enforcement at 90% or higher for package logic.
- Verified the updated package through the sibling `PatternAuthTest` app on a physical iPhone.

### Known Non-Goals

- Argon2id remains a candidate for memory-hard offline attack resistance. v1 uses PBKDF2-HMAC-SHA256 to keep the package dependency-free and SwiftPM-friendly.